### PR TITLE
Add "wave" to list of allowable realms in metadata schema

### DIFF
--- a/au.org.access-nri/model/output/experiment-metadata/1-0-1.json
+++ b/au.org.access-nri/model/output/experiment-metadata/1-0-1.json
@@ -49,7 +49,7 @@
                             "ocnBgchem",
                             "seaIce",
                             "unknown",
-			    "wave"
+                            "wave"
                         ]
                     }
                 ]

--- a/au.org.access-nri/model/output/experiment-metadata/1-0-1.json
+++ b/au.org.access-nri/model/output/experiment-metadata/1-0-1.json
@@ -1,0 +1,164 @@
+{
+    "$id": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/output/experiment-metadata/1-0-1.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Experiment metadata",
+    "description": "The metadata associated with a model experiment",
+    "type": "object",
+    "properties": {
+        "schema_version": {
+            "const": "1-0-1",
+            "description": "The version of the schema (string)"
+        },
+        "name": {
+            "type": "string",
+            "description": "The name of the experiment (string)"
+        },
+        "experiment_uuid": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique uuid for the experiment (string)"
+        },
+        "description": {
+            "type": "string",
+            "description": "Short description of the experiment (string, < 150 char)"
+        },
+        "long_description": {
+            "type": "string",
+            "description": "Long description of the experiment (string)"
+        },
+        "model": {
+            "type": "array",
+            "items": {"type": ["string", "null"]},
+            "description": "The name(s) of the model(s) used in the experiment (string)"
+        },
+        "realm": {
+            "type": "array",
+            "items": {
+                "oneOf": [
+                    {"type": "null"},
+                    {
+                        "type": "string",
+                        "enum": [
+                            "aerosol",
+                            "atmos",
+                            "atmosChem",
+                            "land",
+                            "landIce",
+                            "none",
+                            "ocean",
+                            "ocnBgchem",
+                            "seaIce",
+                            "unknown",
+			    "wave"
+                        ]
+                    }
+                ]
+            },
+            "description": "The realm(s) included in the experiment (string)"
+        },
+        "frequency": {
+            "type": "array",
+            "items": {
+                "oneOf": [
+                    {"type": "null"},
+                    {
+                        "type": "string",
+                        "oneOf": [
+                            {
+                                "pattern": "^fx$"
+                            },
+                            {
+                                "pattern": "^subhr$"
+                            },
+                            {
+                                "pattern": "^\\d+hr$"
+                            },
+                            {
+                                "pattern": "^\\d+day$"
+                            },
+                            {
+                                "pattern": "^\\d+mon$"
+                            },
+                            {
+                                "pattern": "^\\d+yr$"
+                            },
+                            {
+                                "pattern": "^\\d+dec$"
+                            }
+                       ]
+                    }
+                ]
+            },
+            "description": "The frequency(/ies) included in the experiment (string)"
+        },
+        "variable": {
+            "type": "array",
+            "items": {
+                "type": ["string", "null"]
+            },
+            "description": "The variable(s) included in the experiment (string)"
+        },
+        "nominal_resolution": {
+            "type": "array",
+            "items": {"type": ["string", "null"]},
+            "description": "The nominal resolution(s) of model(s) used in the experiment (string)"
+        },
+        "version": {
+            "type": ["number", "string", "null"],
+            "description": "The version of the experiment (number, string)"
+        },
+        "contact": {
+            "type": ["string", "null"],
+            "description": "Contact name for the experiment (string)"
+        },
+        "email": {
+            "type": ["string", "null"],
+            "description": "Email address of the contact for the experiment (string)"
+        },
+        "created": {
+            "type": ["string", "null"],
+            "description": "Initial creation date of experiment (string)"
+        },
+        "reference": {
+            "type": ["string", "null"],
+            "description": "Citation or reference information (string)"
+        },
+        "license": {
+            "type": ["string", "null"],
+            "description": "License of the experiment (string)"
+        },
+        "url": {
+            "type": ["string", "null"],
+            "description": "Relevant url, e.g. github repo for experiment configuration (string)"
+        },
+        "parent_experiment": {
+            "type": ["string", "null"],
+            "description": "experiment_uuid for parent experiment if appropriate (string)"
+        },
+        "related_experiments": {
+            "type": "array",
+            "items": {
+                "type": ["string", "null"]
+            },
+            "description": "experiment_uuids for any related experiment(s) (string)"
+        },
+        "notes": {
+            "type": ["string", "null"],
+            "description": "Additional notes (string)"
+        },
+        "keywords": {
+            "type": "array",
+            "items": {
+                "type": ["string", "null"]
+            },
+            "description": "Keywords to associated with experiment (string)"
+        }
+    },
+    "required": [
+        "name",
+        "experiment_uuid",
+        "description",
+        "long_description"
+    ],
+    "additionalProperties": false
+}

--- a/au.org.access-nri/model/output/experiment-metadata/CHANGELOG.md
+++ b/au.org.access-nri/model/output/experiment-metadata/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Experiment metadata changelog
 
+## 1-0-1
+
+* Add "wave" to list of allowable realms
+
 ## 1-0-0
 
 * Initial release

--- a/au.org.access-nri/model/output/file-metadata/1-0-1.json
+++ b/au.org.access-nri/model/output/file-metadata/1-0-1.json
@@ -1,0 +1,132 @@
+{
+    "$id": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/output/file-metadata/1-0-1.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "File metadata",
+    "description": "The metadata associated with a file containing or referencing climate model data",
+    "type": "object",
+    "properties": {
+        "schema_version": {
+            "const": "1-0-1",
+            "description": "The version of the schema (string)"
+        },
+        "path": {
+            "type": "string",
+            "description": "The path to the file asset"
+        },
+        "realm": {
+            "type": "string",
+            "enum": [
+                "aerosol",
+                "atmos",
+                "atmosChem",
+                "land",
+                "landIce",
+                "none",
+                "ocean",
+                "ocnBgchem",
+                "seaIce",
+                "unknown",
+                "wave"
+            ],
+            "description": "The realm of the data in the file asset"
+        },
+        "variable": {
+            "type": "array",
+            "items": {
+                "type": ["string", "null"]
+            },
+            "description": "The variable(s) in the file asset"
+        },
+        "variable_long_name": {
+            "type": "array",
+            "items": {
+                "type": ["string", "null"]
+            },
+            "description": "The long_name(s) of the variable(s) in the file asset"
+        },
+        "variable_standard_name": {
+            "type": "array",
+            "items": {
+                "type": ["string", "null"]
+            },
+            "description": "The standard_names(s) of the variable(s) in the file asset"
+        },
+        "variable_cell_methods": {
+            "type": "array",
+            "items": {
+                "type": ["string", "null"]
+            },
+            "description": "The cell_methods(s) of the variable(s) in the file asset"
+        },
+        "variable_units": {
+            "type": "array",
+            "items": {
+                "type": ["string", "null"]
+            },
+            "description": "The units of the variable(s) in the file asset"
+        },
+        "frequency": {
+            "type": "string",
+            "oneOf": [
+                {
+                    "pattern": "^fx$"
+                },
+                {
+                    "pattern": "^subhr$"
+                },
+                {
+                    "pattern": "^\\d+hr$"
+                },
+                {
+                    "pattern": "^\\d+day$"
+                },
+                {
+                    "pattern": "^\\d+mon$"
+                },
+                {
+                    "pattern": "^\\d+yr$"
+                },
+                {
+                    "pattern": "^\\d+dec$"
+                }
+            ],
+            "description": "The frequency of the variable(s) in the file asset"
+        },
+        "start_date": {
+            "type": "string",
+             "oneOf": [
+                {
+                    "pattern": "^\\d\\d\\d\\d-\\d\\d-\\d\\d,\\s\\d\\d:\\d\\d:\\d\\d$"
+                },
+                {
+                    "pattern": "none"
+                }
+             ],
+            "description": "The start date of the variable(s) in the file asset"
+        },
+        "end_date": {
+            "type": "string",
+            "oneOf": [
+                {
+                    "pattern": "^\\d\\d\\d\\d-\\d\\d-\\d\\d,\\s\\d\\d:\\d\\d:\\d\\d$"
+                },
+                {
+                    "pattern": "none"
+                }
+             ],
+            "description": "The end date of the variable(s) in the file asset"
+        },
+        "nominal_resolution": {
+            "type": "string",
+            "description": "The nominal resolution of the variable(s) in the file asset"
+        }
+    },
+    "required": [
+        "path",
+        "realm",
+        "variable",
+        "frequency",
+        "start_date",
+        "end_date"
+    ]
+}

--- a/au.org.access-nri/model/output/file-metadata/CHANGELOG.md
+++ b/au.org.access-nri/model/output/file-metadata/CHANGELOG.md
@@ -1,5 +1,9 @@
 # File metadata changelog
 
+## 1-0-1
+
+* Add "wave" to list of allowable realms
+
 ## 1-0-0
 
 * Initial release


### PR DESCRIPTION
This PR adds new versions (1-0-1) of the `model/output/experiment-metadata` and `model/output/file-metadata` schema that include "wave" as an allowable `realm`.

Closes #10 