### PR TITLE
Added initial schema for `spack.location.json` file

### DIFF
--- a/au.org.access-nri/model/spack/environment/location/1-0-0.json
+++ b/au.org.access-nri/model/spack/environment/location/1-0-0.json
@@ -1,0 +1,22 @@
+{
+  "$id": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/spack/environment/location/1-0-0.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "spack.location.json schema",
+  "description": "Schema for the creation of machine-readable metadata as spack.location.json",
+  "type": "object",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^.*@.*$": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "md5hash": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/au.org.access-nri/model/spack/environment/location/CHANGELOG.md
+++ b/au.org.access-nri/model/spack/environment/location/CHANGELOG.md
@@ -1,0 +1,5 @@
+# `spack.yaml` Schema Changelog
+
+## 1-0-0
+
+* Initial release

--- a/au.org.access-nri/model/spack/environment/location/README.md
+++ b/au.org.access-nri/model/spack/environment/location/README.md
@@ -1,0 +1,14 @@
+# ACCESS-OM2 Checksums
+
+This schema is used to validate `spack.location.json` files generated during the automated deployment of models.
+
+## Extending the schema
+
+To modify the schema, a new version of the schema will need to be created.
+
+1. Determine the new schema version: We utilize [`SchemaVer`](https://docs.snowplow.io/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver/) for schema versioning. In a nutshell, `SchemaVer` is a `MODEL-REVISION-ADDITION` format, where:
+    * If adding changes that have no interoperability with the previous schema or historical data, the `MODEL` version should be incremented.
+    * If adding changes that may have interoperability with the previous schema and some historical data, increment the `REVISION` version.
+    * If adding changes that are interoperable with the previous schema and all historical data, increment the `ADDITION` version.
+
+2. Create a new file for the new schema version, e.g. `1-0-1.json`


### PR DESCRIPTION
Addition of a new schema that validates `spack.location.json`, which is generated during automated deployment of models using spack. 

References https://github.com/ACCESS-NRI/build-cd/issues/33