### PR TITLE
`model/deployment/config/versions`: Added `$schema` as a required property

### DIFF
--- a/au.org.access-nri/model/deployment/ config/versions/1-0-0.json
+++ b/au.org.access-nri/model/deployment/ config/versions/1-0-0.json
@@ -5,6 +5,9 @@
     "description": "Schema for specifying versions of repositories used in the deployment of a model",
     "type": "object",
     "properties": {
+        "$schema": {
+            "type": "string"
+        },
         "spack-packages": {
             "type": "string"
         },


### PR DESCRIPTION
While testing out https://github.com/ACCESS-NRI/schema/pull/28 it was noted that the schema would always fail because `$schema` was required but not defined in properties, so it would automatically fail. Since this schema isn't in use yet, it should be able to be modified. 