### PR TITLE
Added 1-0-1.json: Updated 'requires' regex

### DIFF
--- a/au.org.access-nri/model/spack/environment/deployment/1-0-1.json
+++ b/au.org.access-nri/model/spack/environment/deployment/1-0-1.json
@@ -1,0 +1,62 @@
+{
+  "$id": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/spack/environment/deployment/1-0-1.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Restricted spack environment file schema for ACCESS-NRI continuous deployment",
+  "description": "This schema was adapted from https://github.com/ACCESS-NRI/spack/blob/releases/v0.21/lib/spack/spack/schema/env.py to specify a restricted form of spack.yaml to design generic deployment infrastructure.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "spack": {
+      "type": "object",
+      "default": {},
+      "additionalProperties": true,
+      "properties": {
+        "packages": {
+          "type": "object",
+          "default": {},
+          "additionalProperties": true,
+          "patternProperties": {
+            "(?!^all$)(^\\w[\\w-]*)": {
+              "type": "object",
+              "default": {},
+              "additionalProperties": true,
+              "properties": {
+                "require": {
+                  "type": "array",
+                  "minItems": 1,
+                  "additionalItems": true,
+                  "items": [
+                    {
+                      "type": "string",
+                      "pattern": "^@[A-Za-z0-9.\\-_=]$"
+                    },
+                    {
+                      "oneOf": [
+                        {
+                          "type": "object"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "specs": {
+          "type": "array",
+          "default": [],
+          "minItems": 1,
+          "maxItems": 1,
+          "items": {
+            "type": "string",
+            "pattern": "^.*@git\\.[A-Za-z0-9.\\-_]+$"
+          }
+        }
+      }
+    }
+  }
+}

--- a/au.org.access-nri/model/spack/environment/deployment/CHANGELOG.md
+++ b/au.org.access-nri/model/spack/environment/deployment/CHANGELOG.md
@@ -1,5 +1,9 @@
 # `spack.yaml` Schema Changelog
 
+## 1-0-1
+
+* Modified regex of `spack.packages.*.require[0]` to include `=` as a symbol. This allows versions like `@git.2024.05.28=access-esm1.5`. See issue https://github.com/ACCESS-NRI/spack-packages/issues/111 and related PR https://github.com/ACCESS-NRI/build-cd/pull/87. This has full interoperability with the earlier schema. 
+
 ## 1-0-0
 
 * Initial release


### PR DESCRIPTION
See related issue: https://github.com/ACCESS-NRI/spack-packages/issues/111

In this PR:
* We allow `=` in our version of `spack.yaml`, since we need to be able to `@git.TAG=VERSION` in our `spack.packages.*.requires[0]` statement. 