### PR TITLE
Add `ci.schema.json` from `ACCESS-NRI/access-om2-configs`

### DIFF
--- a/.github/actions/validate-with-schema/README.md
+++ b/.github/actions/validate-with-schema/README.md
@@ -9,6 +9,7 @@ This action validates a `json` or `yaml` file using a given schema. Essentially 
 | `schema-version` | `string` | Version of the schema required in SchemaVer | `true` | N/A | `"1-0-0"` |
 | `schema-location` | `string` | Directory within access-nri/schema that contains the schema | `true` | N/A | `"access-nri.org.au/deployment/config/versions"` |
 | `data-location` | `string` | Path(s) to the json/yaml data file(s) in the callers repository. File is either `.json` or `.yml`/`.yaml` | `true` | N/A | `"./some/data.json"` or `"/path/to/some/data.yaml"` or ```./file1 \n ./file2``` if newline-separated |
+| `meta-schema-location` | `string` | Meta schema version of the schema required | `false` | `"draft-07"` | `"draft-07"` or `"draft-2019-09"` or `"draft-2020-12"` |
 
 ## Outputs
 

--- a/.github/actions/validate-with-schema/action.yml
+++ b/.github/actions/validate-with-schema/action.yml
@@ -13,6 +13,13 @@ inputs:
     type: string
     required: true
     description: Path(s) to the data file(s) in the callers repository
+  meta-schema-version:
+    type: string
+    required: false
+    default: draft-07
+    description: |
+      Meta schema version of the schema required.
+      Accepts 'draft-07', 'draft-2019-09', 'draft-2020-12'.
 runs:
   using: composite
   steps:
@@ -39,6 +46,7 @@ runs:
         files: |
           ${{ inputs.data-location }}
         json_schema: schema/${{ inputs.schema-location }}/${{ inputs.schema-version }}.json
+        json_schema_version: ${{ inputs.meta-schema-version }}
         yaml_as_json: true
         ajv_strict_mode: false
         use_gitignore: false

--- a/au.org.access-nri/model/configuration/ci/1-0-0.json
+++ b/au.org.access-nri/model/configuration/ci/1-0-0.json
@@ -1,0 +1,79 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Model Configuration CI Testing Configuration",
+    "description": "Settings for Continuous Integration (CI) tests for model configurations repositories",
+    "type": "object",
+    "$defs": {
+        "config": {
+            "type": "object",
+            "properties": {
+                "markers": {
+                    "type": "string",
+                    "description": "A python expression of markers to pass to model-config-tests pytests"
+                },
+                "model-config-tests-version": {
+                    "type": "string",
+                    "description": "A version of the model-config-tests package"
+                },
+                "python-version": {
+                    "type": "string",
+                    "description": "The python version used to create test virtual environment"
+                }
+            },
+            "additionalProperties": false
+        },
+        "check": {
+            "type": "object",
+            "patternProperties": {
+                "^.*$": {
+                    "$ref": "#/$defs/config",
+                    "description": "The name of the git branch or tag"
+                },
+                "default": {
+                    "$ref": "#/$defs/config",
+                    "required": [
+                        "markers"
+                    ],
+                    "description": "The default configuration for this check"
+                }
+            },
+            "required": [
+                "default"
+            ],
+            "additionalProperties": false
+        }
+    },
+    "properties": {
+        "$schema": {
+            "type": "string"
+        },
+        "scheduled": {
+            "$ref": "#/$defs/check",
+            "description": "Scheduled reproducibility checks. The keys are config tags to run scheduled checks on"
+        },
+        "reproducibility": {
+            "$ref": "#/$defs/check",
+            "description": "Reproducibility checks. The keys are the target branch names for pull requests"
+        },
+        "qa": {
+            "$ref": "#/$defs/check",
+            "description": "Quick quality assurance checks. The keys are the target branch names for pull requests"
+        },
+        "default": {
+            "$ref": "#/$defs/config",
+            "required": [
+                "model-config-tests-version",
+                "python-version"
+            ],
+            "description": "Global default configuration"
+        }
+    },
+    "required": [
+        "$schema",
+        "scheduled",
+        "reproducibility",
+        "qa",
+        "default"
+    ],
+    "additionalProperties": false
+}

--- a/au.org.access-nri/model/configuration/ci/CHANGELOG.md
+++ b/au.org.access-nri/model/configuration/ci/CHANGELOG.md
@@ -1,0 +1,5 @@
+# `Model Configs CI Configuration` Changelog
+
+## 1-0-0
+
+* Initial release, moved from https://github.com/ACCESS-NRI/access-om2-configs/pull/116

--- a/au.org.access-nri/model/configuration/ci/README.md
+++ b/au.org.access-nri/model/configuration/ci/README.md
@@ -1,6 +1,6 @@
-# Model Configuration Checksums
+# Model Configuration CI Testing
 
-This schema is used to consolidate versions and defaults for multiple aspects of the model configuration CI pipeline, including reproducibility checks, QA checks, and scheduled checks.
+This schema is used to consolidate versions and defaults for multiple aspects of the model configuration CI pipeline, including reproducibility checks, QA checks, and scheduled checks. For more information on these tests, see  the [ACCESS-NRI/model-config-tests](https://github.com/ACCESS-NRI/model-config-tests/) repository.
 
 ## Extending the schema
 

--- a/au.org.access-nri/model/configuration/ci/README.md
+++ b/au.org.access-nri/model/configuration/ci/README.md
@@ -1,0 +1,14 @@
+# Model Configuration Checksums
+
+This schema is used to consolidate versions and defaults for multiple aspects of the model configuration CI pipeline, including reproducibility checks, QA checks, and scheduled checks.
+
+## Extending the schema
+
+To modify the schema, a new version of the schema will need to be created.
+
+1. Determine the new schema version: We utilize [`SchemaVer`](https://docs.snowplow.io/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver/) for schema versioning. In a nutshell, `SchemaVer` is a `MODEL-REVISION-ADDITION` format, where:
+    * If adding changes that have no interoperability with the previous schema or historical data, the `MODEL` version should be incremented.
+    * If adding changes that may have interoperability with the previous schema and some historical data, increment the `REVISION` version.
+    * If adding changes that are interoperable with the previous schema and all historical data, increment the `ADDITION` version.
+
+2. Create a new file for the new schema version, e.g. `1-0-1.json`


### PR DESCRIPTION
Moving the schema that was removed from https://github.com/ACCESS-NRI/access-om2-configs/pull/116 into here, and updating the action to allow for different metaschema versions. 

In this PR:
* Moved `ci.schema.json` into `au.org.access-nri/model/configuration/ci/1-0-0.json`, added `README.md` and `CHANGELOG.md`
* Updated `validate-with-schema` action to allow picking of metaschema version as the above schema is `2020-12`, not the default `draft07`

References ACCESS-NRI/model-config-tests#23