### PR TITLE
Update `spack.packages.*.require[0]` to allow `/` in branches

### DIFF
--- a/au.org.access-nri/model/spack/environment/deployment/1-0-2.json
+++ b/au.org.access-nri/model/spack/environment/deployment/1-0-2.json
@@ -28,7 +28,7 @@
                   "items": [
                     {
                       "type": "string",
-                      "pattern": "^@[A-Za-z0-9.\\-_=/]+$"
+                      "pattern": "^@[A-Za-z0-9.\\-_=\/]+$"
                     },
                     {
                       "oneOf": [

--- a/au.org.access-nri/model/spack/environment/deployment/1-0-2.json
+++ b/au.org.access-nri/model/spack/environment/deployment/1-0-2.json
@@ -1,0 +1,62 @@
+{
+  "$id": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/spack/environment/deployment/1-0-2.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Restricted spack environment file schema for ACCESS-NRI continuous deployment",
+  "description": "This schema was adapted from https://github.com/ACCESS-NRI/spack/blob/releases/v0.21/lib/spack/spack/schema/env.py to specify a restricted form of spack.yaml to design generic deployment infrastructure.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "spack": {
+      "type": "object",
+      "default": {},
+      "additionalProperties": true,
+      "properties": {
+        "packages": {
+          "type": "object",
+          "default": {},
+          "additionalProperties": true,
+          "patternProperties": {
+            "(?!^all$)(^\\w[\\w-]*)": {
+              "type": "object",
+              "default": {},
+              "additionalProperties": true,
+              "properties": {
+                "require": {
+                  "type": "array",
+                  "minItems": 1,
+                  "additionalItems": true,
+                  "items": [
+                    {
+                      "type": "string",
+                      "pattern": "^@[A-Za-z0-9.\\-_=/]+$"
+                    },
+                    {
+                      "oneOf": [
+                        {
+                          "type": "object"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "specs": {
+          "type": "array",
+          "default": [],
+          "minItems": 1,
+          "maxItems": 1,
+          "items": {
+            "type": "string",
+            "pattern": "^.*@git\\.[A-Za-z0-9.\\-_]+$"
+          }
+        }
+      }
+    }
+  }
+}

--- a/au.org.access-nri/model/spack/environment/deployment/CHANGELOG.md
+++ b/au.org.access-nri/model/spack/environment/deployment/CHANGELOG.md
@@ -1,8 +1,12 @@
 # `spack.yaml` Schema Changelog
 
+## 1-0-2
+
+* Updated `spack.packages.*.require[0]` syntax to allow for versions that have a `/` in them. For example, `spack.packages.mypackage.require[0] == @git.user/feature` allows the `mypackage` to use the branch `user/feature` as a version. This has full interoperability with the earlier schema.
+
 ## 1-0-1
 
-* Modified regex of `spack.packages.*.require[0]` to include `=` as a symbol. This allows versions like `@git.2024.05.28=access-esm1.5`. See issue https://github.com/ACCESS-NRI/spack-packages/issues/111 and related PR https://github.com/ACCESS-NRI/build-cd/pull/87. This has full interoperability with the earlier schema. 
+* Modified regex of `spack.packages.*.require[0]` to include `=` as a symbol. This allows versions like `@git.2024.05.28=access-esm1.5`. See issue https://github.com/ACCESS-NRI/spack-packages/issues/111 and related PR https://github.com/ACCESS-NRI/build-cd/pull/87. This has full interoperability with the earlier schema.
 
 ## 1-0-0
 


### PR DESCRIPTION
See failed run: https://github.com/ACCESS-NRI/ACCESS-OM2/actions/runs/10416178348/job/28847949274

This PR updates the schema for our own restricted `spack.yaml`. Namely, `spack.packages.*.require[0]` now allows `/` in the version strings. This allows for branches such as `user/feature1` in package versions, like so: `@git.user/feature1`. 

In this PR:
* Update to a new schema version `1-0-2`
* Update CHANGELOG for `au.org.access-nri.model.spack.environment.deployment` schema

Since the diff doesn't help much, do `diff au.org.access-nri/model/spack/environment/deployment/1-0-1.json au.org.access-nri/model/spack/environment/deployment/1-0-2.json`. 

References https://github.com/ACCESS-NRI/ACCESS-OM2/pull/76
