### PR TITLE
Add `payu-version` field to `configs/ci.json` schema

### DIFF
--- a/au.org.access-nri/model/configuration/ci/2-0-0.json
+++ b/au.org.access-nri/model/configuration/ci/2-0-0.json
@@ -18,7 +18,7 @@
                 },
                 "python-version": {
                     "type": "string",
-                    "description": "The python version used to create test virtual environment"
+                    "description": "The python version used to create test virtual environment on Github hosted tests"
                 },
                 "payu-version": {
                     "type": "string",

--- a/au.org.access-nri/model/configuration/ci/2-0-0.json
+++ b/au.org.access-nri/model/configuration/ci/2-0-0.json
@@ -1,0 +1,85 @@
+{
+    "$id": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/configuration/ci/2-0-0.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Model Configuration CI Testing Configuration",
+    "description": "Settings for Continuous Integration (CI) tests for model configurations repositories",
+    "type": "object",
+    "$defs": {
+        "config": {
+            "type": "object",
+            "properties": {
+                "markers": {
+                    "type": "string",
+                    "description": "A python expression of markers to pass to model-config-tests pytests"
+                },
+                "model-config-tests-version": {
+                    "type": "string",
+                    "description": "A version of the model-config-tests package"
+                },
+                "python-version": {
+                    "type": "string",
+                    "description": "The python version used to create test virtual environment"
+                },
+                "payu-version": {
+                    "type": "string",
+                    "description": "The Payu version used to run the model configurations"
+                }
+            },
+            "additionalProperties": false
+        },
+        "check": {
+            "type": "object",
+            "patternProperties": {
+                "^.*$": {
+                    "$ref": "#/$defs/config",
+                    "description": "The name of the git branch or tag"
+                },
+                "default": {
+                    "$ref": "#/$defs/config",
+                    "required": [
+                        "markers"
+                    ],
+                    "description": "The default configuration for this check"
+                }
+            },
+            "required": [
+                "default"
+            ],
+            "additionalProperties": false
+        }
+    },
+    "properties": {
+        "$schema": {
+            "type": "string"
+        },
+        "scheduled": {
+            "$ref": "#/$defs/check",
+            "description": "Scheduled reproducibility checks. The keys are config tags to run scheduled checks on"
+        },
+        "reproducibility": {
+            "$ref": "#/$defs/check",
+            "description": "Reproducibility checks. The keys are the target branch names for pull requests"
+        },
+        "qa": {
+            "$ref": "#/$defs/check",
+            "description": "Quick quality assurance checks. The keys are the target branch names for pull requests"
+        },
+        "default": {
+            "$ref": "#/$defs/config",
+            "required": [
+                "model-config-tests-version",
+                "python-version",
+                "payu-version"
+            ],
+            "description": "Global default configuration"
+        }
+    },
+    "required": [
+        "$schema",
+        "scheduled",
+        "reproducibility",
+        "qa",
+        "default"
+    ],
+    "additionalProperties": false
+}

--- a/au.org.access-nri/model/configuration/ci/CHANGELOG.md
+++ b/au.org.access-nri/model/configuration/ci/CHANGELOG.md
@@ -1,5 +1,9 @@
 # `Model Configs CI Configuration` Changelog
 
+## 2-0-0
+
+* Added required `payu-version` field to all levels of configuration
+
 ## 1-0-0
 
 * Initial release, moved from https://github.com/ACCESS-NRI/access-om2-configs/pull/116


### PR DESCRIPTION
Add a `payu-version` field to the `*-configs` repos `config/ci.json` schema.

Diffs are always funny with these schema updates, so run `diff au.org.access-nri/model/configuration/ci/1-0-0.json au.org.access-nri/model/configuration/ci/2-0-0.json`. 

In this PR:
* Updated `au.org.access-nri/model/configuration/ci` to `2-0-0`
* Added required `payu-version` field to all levels of configuration
* Updated CHANGELOG

References ACCESS-NRI/model-config-tests#37