### PR TITLE
Deployment Repo `config/versions.json` Schema No Longer Requires `spack-config`

### DIFF
--- a/au.org.access-nri/model/deployment/config/versions/2-0-0.json
+++ b/au.org.access-nri/model/deployment/config/versions/2-0-0.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/1-0-0.json",
+    "$id": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/2-0-0.json",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Deployment Configuration for Versions",
     "description": "Schema for specifying versions of repositories used in the deployment of a model",

--- a/au.org.access-nri/model/deployment/config/versions/3-0-0.json
+++ b/au.org.access-nri/model/deployment/config/versions/3-0-0.json
@@ -1,0 +1,20 @@
+{
+    "$id": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Deployment Configuration for Versions",
+    "description": "Schema for specifying versions of repositories used in the deployment of a model",
+    "type": "object",
+    "properties": {
+        "$schema": {
+            "type": "string"
+        },
+        "spack": {
+            "type": "string"
+        },
+        "spack-packages": {
+            "type": "string"
+        }
+    },
+    "required": [ "$schema", "spack", "spack-packages" ],
+    "additionalProperties": false
+}

--- a/au.org.access-nri/model/deployment/config/versions/CHANGELOG.md
+++ b/au.org.access-nri/model/deployment/config/versions/CHANGELOG.md
@@ -7,3 +7,7 @@
 ## 2-0-0
 
 * Added required `spack` version. This hard requirement means this schema and historical data is not interoperable.
+
+## 3-0-0
+
+* Removed `spack-config` version as it is being incorporated into `build-cd` - see this [Pull Request](https://github.com/ACCESS-NRI/build-cd/pull/128). Since this was a `required` property in the schema, this schema is not interoperable with historical data.


### PR DESCRIPTION
Update the `au.org.access-nri/model/deployment/config/versions` schema to no longer include the required `spack-config` field, as that will now be handled by `build-cd`s `config/settings.json` file.
Also took the opportunity to update the `$id` field of the `2-0-0` version of the schema. 

See the diff properly with `diff -- au.org.access-nri/model/deployment/config/versions/2-0-0.json au.org.access-nri/model/deployment/config/versions/3-0-0.json`

In this PR:
- Add `au.org.access-nri/model/deployment/config/versions` schema `3-0-0`
- Update `au.org.access-nri/model/deployment/config/versions` schema `2-0-0`s `$id` field

References ACCESS-NRI/build-cd#123
