### PR TITLE
Fix for Finding Data Locations not at `.`

### DIFF
--- a/.github/actions/validate-with-schema/action.yml
+++ b/.github/actions/validate-with-schema/action.yml
@@ -26,7 +26,7 @@ runs:
     # Ensure that the calling workflow has checked out an appropriate git repository.
     - shell: bash
       run: |
-        if ! git status; then
+        if ! git -C $(dirname ${{ inputs.data-location }}) status; then
           echo "::error::Calling repository not checked out. Failing..."
           exit 1
         fi


### PR DESCRIPTION
In this PR:
- Update the `git status` command that checks that the calling workflow has checked out a repository by having the `git` command run in the directory of the file of the `inputs.data-location`

Closes ACCESS-NRI/build-cd#133
