### PR TITLE
Update schema to support multi-target `spack.yaml`

### DIFF
--- a/au.org.access-nri/model/spack/environment/deployment/1-0-3.json
+++ b/au.org.access-nri/model/spack/environment/deployment/1-0-3.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/spack/environment/deployment/1-0-2.json",
+  "$id": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/spack/environment/deployment/1-0-3.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Restricted spack environment file schema for ACCESS-NRI continuous deployment",
   "description": "This schema was adapted from https://github.com/ACCESS-NRI/spack/blob/releases/v0.21/lib/spack/spack/schema/env.py to specify a restricted form of spack.yaml to design generic deployment infrastructure.",

--- a/au.org.access-nri/model/spack/environment/deployment/1-0-4.json
+++ b/au.org.access-nri/model/spack/environment/deployment/1-0-4.json
@@ -1,5 +1,6 @@
 {
     "$id": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/spack/environment/deployment/1-0-4.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Restricted spack environment file schema for ACCESS-NRI continuous deployment",
     "description": "This schema was adapted from https://github.com/ACCESS-NRI/spack/blob/releases/v0.21/lib/spack/spack/schema/env.py to specify a restricted form of spack.yaml to design generic deployment infrastructure.",
     "type": "object",

--- a/au.org.access-nri/model/spack/environment/deployment/1-0-4.json
+++ b/au.org.access-nri/model/spack/environment/deployment/1-0-4.json
@@ -52,43 +52,87 @@
             "maxItems": 1,
             "items": {
               "type": "string",
-              "pattern": "^.+@git\\.[^ ]+.*$|\\$root-spec"
+              "pattern": "^.+@git\\.[^ ]+.*$|\\$ROOT_SPEC"
             }
           },
           "definitions": {
             "type": "array",
             "default": [],
-            "minItems": 0,
-            "oneOf": [
-              {
-                "contains": {
-                  "type": "object",
-                  "required": ["root_package"],
-                  "not": {
-                    "required": ["when"]
-                  }
-                }
-              },
-              {
-                "type": "array",
-                "maxItems": 0
-              }
-            ],
             "items": {
               "type": "object",
               "properties": {
                 "when": {
                   "type": "string"
                 },
-                "root_package": {
+                "ROOT_PACKAGE": {
                   "type": "array",
                   "minItems": 1,
                   "maxItems": 1,
                   "items": {
                     "type": "string"
                   }
+                },
+                "ROOT_SPEC": {
+                  "type": "array",
+                  "items": {
+                    "type":"object",
+                    "properties": {
+                      "matrix": {
+                        "type": "array",
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "exclude": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
                 }
               }
+            }
+          }
+        }
+      }
+    },
+    "if": {
+      "properties": {
+        "spack": {
+          "properties": {
+            "specs": {
+              "contains": {
+                "const": "$ROOT_SPEC"
+              }
+            }
+          }
+        }
+      }
+    },
+    "then": {
+      "properties": {
+        "spack": {
+          "properties": {
+            "definitions": {
+              "allOf": [
+                {
+                  "contains": {
+                    "type": "object",
+                    "required": ["ROOT_SPEC"]
+                  }
+                },
+                {
+                  "contains": {
+                    "type": "object",
+                    "required": ["ROOT_PACKAGE"]
+                  }
+                }
+              ]
             }
           }
         }

--- a/au.org.access-nri/model/spack/environment/deployment/1-0-4.json
+++ b/au.org.access-nri/model/spack/environment/deployment/1-0-4.json
@@ -1,0 +1,97 @@
+{
+    "$id": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/spack/environment/deployment/1-0-4.json",
+    "title": "Restricted spack environment file schema for ACCESS-NRI continuous deployment",
+    "description": "This schema was adapted from https://github.com/ACCESS-NRI/spack/blob/releases/v0.21/lib/spack/spack/schema/env.py to specify a restricted form of spack.yaml to design generic deployment infrastructure.",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "spack": {
+        "type": "object",
+        "default": {},
+        "additionalProperties": true,
+        "properties": {
+          "packages": {
+            "type": "object",
+            "default": {},
+            "additionalProperties": true,
+            "patternProperties": {
+              "(?!^all$)(^\\w[\\w-]*)": {
+                "type": "object",
+                "default": {},
+                "additionalProperties": true,
+                "properties": {
+                  "require": {
+                    "type": "array",
+                    "minItems": 1,
+                    "additionalItems": true,
+                    "items": [
+                      {
+                        "type": "string",
+                        "pattern": "^@[A-Za-z0-9.\\-_=\/]+$"
+                      },
+                      {
+                        "oneOf": [
+                          {
+                            "type": "object"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "specs": {
+            "type": "array",
+            "default": [],
+            "minItems": 1,
+            "maxItems": 1,
+            "items": {
+              "type": "string",
+              "pattern": "^.+@git\\.[^ ]+.*$|\\$root-spec"
+            }
+          },
+          "definitions": {
+            "type": "array",
+            "default": [],
+            "minItems": 0,
+            "oneOf": [
+              {
+                "contains": {
+                  "type": "object",
+                  "required": ["root_package"],
+                  "not": {
+                    "required": ["when"]
+                  }
+                }
+              },
+              {
+                "type": "array",
+                "maxItems": 0
+              }
+            ],
+            "items": {
+              "type": "object",
+              "properties": {
+                "when": {
+                  "type": "string"
+                },
+                "root_package": {
+                  "type": "array",
+                  "minItems": 1,
+                  "maxItems": 1,
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }

--- a/au.org.access-nri/model/spack/environment/deployment/CHANGELOG.md
+++ b/au.org.access-nri/model/spack/environment/deployment/CHANGELOG.md
@@ -1,5 +1,12 @@
 # `spack.yaml` Schema Changelog
 
+## 1-0-4
+
+* Updated `spack.definitions` to require definitions for `ROOT_PACKAGE` and `ROOT_SPEC` iff `spack.specs` contains `"$ROOT_SPEC"`.
+* Updated `spack.specs` to allow `"$ROOT_SPEC"` in speclist.
+
+This has full interoperability with the earlier schema/data.
+
 ## 1-0-3
 
 * Updated `spack.specs` pattern to allow variants following the `@git.VERSION`. This has full interoperability with the earlier schema.


### PR DESCRIPTION
References ACCESS-NRI/model-deployment-template#15

To diff this schema, do `diff -- au.org.access-nri/model/spack/environment/deployment/1-0-3.json au.org.access-nri/model/spack/environment/deployment/1-0-4.json` since it is a new file. 

## Background

This PR updates the schema that contains ACCESS-NRI-flavoured restrictions on `spack.yaml`. The changes are as follows:

* Update `spack.specs[]` to allow `"$ROOT_SPEC"` as a valid value
* Update `spack.definitions` to require definitions for `ROOT_PACKAGE`/`ROOT_SPEC` **only if** `spack.specs` contains `$ROOT_SPEC`

Also had some other changes:

- `1-0-3.json`: Update `$id` to be correctly referencing itself
- Updated `CHANGELOG.md`

## Testing

Tested this schema against https://github.com/ACCESS-NRI/ACCESS-OM2/blob/multi-target-spack-yaml-format/spack.yaml, specifically:

* When `$ROOT_SPEC` exists in `spack.specs` but `ROOT_SPEC`/`ROOT_PACKAGE` doesn't (expected failure)
* When `$ROOT_SPEC` exists in `spack.specs` and `ROOT_SPEC`/`ROOT_PACKAGE` both exist (expected success)
* When `$ROOT_SPEC` doesn't exist in `spack.specs` and `ROOT_SPEC`/`ROOT_PACKAGE` doesn't (expected success)
* When `$ROOT_SPEC` doesn't exist in `spack.specs` but `ROOT_SPEC`/`ROOT_PACKAGE` both exist (expected success)

Can be tested via `ajv --strict=true -s au.org.access-nri/model/spack/environment/deployment/1-0-4.json -d ../ACCESS-OM2/spack.yaml`
