### PR TITLE
Fix validate-schema.yml metaschema download

### DIFF
--- a/.github/workflows/validate-schema.yml
+++ b/.github/workflows/validate-schema.yml
@@ -56,7 +56,8 @@ jobs:
           fi
 
           echo "Metaschema URL: $schema_url"
-          curl -o ${{ env.METASCHEMA_PATH }} $schema_url
+          # Download the metaschema - Use -L to follow any redirects from http to https
+          curl -L -o ${{ env.METASCHEMA_PATH }} $schema_url
 
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
In `validate-schema.yml`: Add `-L` to curl command when downloading metaschema to follow re-directs. This is avoid schema urls such as `http://json-schema.org/draft-07/schema#` responding with `301 Moved Permanently` as it re-directs to the `https://` version of the url. 

Closes #40 