### PR TITLE
Relax Constraints on `spack.specs`

### DIFF
--- a/au.org.access-nri/model/spack/environment/deployment/1-0-5.json
+++ b/au.org.access-nri/model/spack/environment/deployment/1-0-5.json
@@ -50,7 +50,6 @@
             "type": "array",
             "default": [],
             "minItems": 1,
-            "maxItems": 1,
             "items": {
               "type": "string",
               "pattern": "^.+@git\\.[^ ]+.*$|\\$ROOT_SPEC"

--- a/au.org.access-nri/model/spack/environment/deployment/1-0-5.json
+++ b/au.org.access-nri/model/spack/environment/deployment/1-0-5.json
@@ -52,7 +52,7 @@
             "minItems": 1,
             "items": {
               "type": "string",
-              "pattern": "^.+@git\\.[^ ]+.*$|\\$ROOT_SPEC"
+              "pattern": "^.+@git\\.[^= ]+.*$|\\$ROOT_SPEC"
             }
           },
           "definitions": {

--- a/au.org.access-nri/model/spack/environment/deployment/1-0-5.json
+++ b/au.org.access-nri/model/spack/environment/deployment/1-0-5.json
@@ -1,0 +1,142 @@
+{
+    "$id": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/spack/environment/deployment/1-0-5.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Restricted spack environment file schema for ACCESS-NRI continuous deployment",
+    "description": "This schema was adapted from https://github.com/ACCESS-NRI/spack/blob/releases/v0.21/lib/spack/spack/schema/env.py to specify a restricted form of spack.yaml to design generic deployment infrastructure.",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "spack": {
+        "type": "object",
+        "default": {},
+        "additionalProperties": true,
+        "properties": {
+          "packages": {
+            "type": "object",
+            "default": {},
+            "additionalProperties": true,
+            "patternProperties": {
+              "(?!^all$)(^\\w[\\w-]*)": {
+                "type": "object",
+                "default": {},
+                "additionalProperties": true,
+                "properties": {
+                  "require": {
+                    "type": "array",
+                    "minItems": 1,
+                    "additionalItems": true,
+                    "items": [
+                      {
+                        "type": "string",
+                        "pattern": "^@[A-Za-z0-9.\\-_=\/]+$"
+                      },
+                      {
+                        "oneOf": [
+                          {
+                            "type": "object"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "specs": {
+            "type": "array",
+            "default": [],
+            "minItems": 1,
+            "maxItems": 1,
+            "items": {
+              "type": "string",
+              "pattern": "^.+@git\\.[^ ]+.*$|\\$ROOT_SPEC"
+            }
+          },
+          "definitions": {
+            "type": "array",
+            "default": [],
+            "items": {
+              "type": "object",
+              "properties": {
+                "when": {
+                  "type": "string"
+                },
+                "ROOT_PACKAGE": {
+                  "type": "array",
+                  "minItems": 1,
+                  "maxItems": 1,
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "ROOT_SPEC": {
+                  "type": "array",
+                  "items": {
+                    "type":"object",
+                    "properties": {
+                      "matrix": {
+                        "type": "array",
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "exclude": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "if": {
+      "properties": {
+        "spack": {
+          "properties": {
+            "specs": {
+              "contains": {
+                "const": "$ROOT_SPEC"
+              }
+            }
+          }
+        }
+      }
+    },
+    "then": {
+      "properties": {
+        "spack": {
+          "properties": {
+            "definitions": {
+              "allOf": [
+                {
+                  "contains": {
+                    "type": "object",
+                    "required": ["ROOT_SPEC"]
+                  }
+                },
+                {
+                  "contains": {
+                    "type": "object",
+                    "required": ["ROOT_PACKAGE"]
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  }

--- a/au.org.access-nri/model/spack/environment/deployment/1-0-5.json
+++ b/au.org.access-nri/model/spack/environment/deployment/1-0-5.json
@@ -104,8 +104,10 @@
     "if": {
       "properties": {
         "spack": {
+          "type": "object",
           "properties": {
             "specs": {
+              "type": "array",
               "contains": {
                 "const": "$ROOT_SPEC"
               }
@@ -117,16 +119,19 @@
     "then": {
       "properties": {
         "spack": {
+          "type": "object",
           "properties": {
             "definitions": {
               "allOf": [
                 {
+                  "type": "array",
                   "contains": {
                     "type": "object",
                     "required": ["ROOT_SPEC"]
                   }
                 },
                 {
+                  "type": "array",
                   "contains": {
                     "type": "object",
                     "required": ["ROOT_PACKAGE"]

--- a/au.org.access-nri/model/spack/environment/deployment/CHANGELOG.md
+++ b/au.org.access-nri/model/spack/environment/deployment/CHANGELOG.md
@@ -1,5 +1,12 @@
 # `spack.yaml` Schema Changelog
 
+## 1-0-5
+
+* Updated `spack.specs` to allow > 1 specs allowed. The first spec is still used as a basis for deployment information.
+* Updated `spack.specs` pattern to allow `=VERSION` after `@git.REF`
+
+This has full interoperability with the earlier schema/data.
+
 ## 1-0-4
 
 * Updated `spack.definitions` to require definitions for `ROOT_PACKAGE` and `ROOT_SPEC` iff `spack.specs` contains `"$ROOT_SPEC"`.


### PR DESCRIPTION
References ACCESS-NRI/build-cd#223

## Background

> [!NOTE]
> To view the diff properly (since `1-0-5.json` is a new file), run `git diff e9b7a72..bb16d04` or !github version!

This PR relaxes some of the constraints on the `spack.yaml`. 

In this PR:

- **Add 1-0-5.json as copy of 1-0-4.json**
- **Remove maximum-of-1 constraint on `spack.specs`**
- **Break on `=` after ref to explicitly support `=VERSION`**
- **Add type specifiers for strict-mode validation**
