### PR TITLE
`spack.yaml` schema: Special-case `spack.packages.gcc-runtime.requires[0]` requires no version 

### DIFF
--- a/au.org.access-nri/model/spack/environment/deployment/1-0-6.json
+++ b/au.org.access-nri/model/spack/environment/deployment/1-0-6.json
@@ -15,6 +15,30 @@
             "type": "object",
             "default": {},
             "additionalProperties": true,
+            "properties": {
+              "gcc-runtime": {
+                "type": "object",
+                "default": {},
+                "additionalProperties": true,
+                "properties": {
+                  "require": {
+                    "type": "array",
+                    "minItems": 1,
+                    "additionalItems": true,
+                    "items": {
+                      "oneOf": [
+                        {
+                          "type": "object"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            },
             "patternProperties": {
               "(?!^all$)(^\\w[\\w-]*)": {
                 "type": "object",

--- a/au.org.access-nri/model/spack/environment/deployment/1-0-6.json
+++ b/au.org.access-nri/model/spack/environment/deployment/1-0-6.json
@@ -40,7 +40,7 @@
               }
             },
             "patternProperties": {
-              "(?!^all$)(^\\w[\\w-]*)": {
+              "(?!^(all|gcc-runtime)$)(^\\w[\\w-]*)": {
                 "type": "object",
                 "default": {},
                 "additionalProperties": true,

--- a/au.org.access-nri/model/spack/environment/deployment/1-0-6.json
+++ b/au.org.access-nri/model/spack/environment/deployment/1-0-6.json
@@ -1,0 +1,146 @@
+{
+    "$id": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/spack/environment/deployment/1-0-6.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Restricted spack environment file schema for ACCESS-NRI continuous deployment",
+    "description": "This schema was adapted from https://github.com/ACCESS-NRI/spack/blob/releases/v0.21/lib/spack/spack/schema/env.py to specify a restricted form of spack.yaml to design generic deployment infrastructure.",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "spack": {
+        "type": "object",
+        "default": {},
+        "additionalProperties": true,
+        "properties": {
+          "packages": {
+            "type": "object",
+            "default": {},
+            "additionalProperties": true,
+            "patternProperties": {
+              "(?!^all$)(^\\w[\\w-]*)": {
+                "type": "object",
+                "default": {},
+                "additionalProperties": true,
+                "properties": {
+                  "require": {
+                    "type": "array",
+                    "minItems": 1,
+                    "additionalItems": true,
+                    "items": [
+                      {
+                        "type": "string",
+                        "pattern": "^@[A-Za-z0-9.\\-_=\/]+$"
+                      },
+                      {
+                        "oneOf": [
+                          {
+                            "type": "object"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "specs": {
+            "type": "array",
+            "default": [],
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "pattern": "^.+@git\\.[^= ]+.*$|\\$ROOT_SPEC"
+            }
+          },
+          "definitions": {
+            "type": "array",
+            "default": [],
+            "items": {
+              "type": "object",
+              "properties": {
+                "when": {
+                  "type": "string"
+                },
+                "ROOT_PACKAGE": {
+                  "type": "array",
+                  "minItems": 1,
+                  "maxItems": 1,
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "ROOT_SPEC": {
+                  "type": "array",
+                  "items": {
+                    "type":"object",
+                    "properties": {
+                      "matrix": {
+                        "type": "array",
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "exclude": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "if": {
+      "properties": {
+        "spack": {
+          "type": "object",
+          "properties": {
+            "specs": {
+              "type": "array",
+              "contains": {
+                "const": "$ROOT_SPEC"
+              }
+            }
+          }
+        }
+      }
+    },
+    "then": {
+      "properties": {
+        "spack": {
+          "type": "object",
+          "properties": {
+            "definitions": {
+              "allOf": [
+                {
+                  "type": "array",
+                  "contains": {
+                    "type": "object",
+                    "required": ["ROOT_SPEC"]
+                  }
+                },
+                {
+                  "type": "array",
+                  "contains": {
+                    "type": "object",
+                    "required": ["ROOT_PACKAGE"]
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  }

--- a/au.org.access-nri/model/spack/environment/deployment/CHANGELOG.md
+++ b/au.org.access-nri/model/spack/environment/deployment/CHANGELOG.md
@@ -1,5 +1,9 @@
 # `spack.yaml` Schema Changelog
 
+## 1-0-6
+
+* Added special case for `spack.packages.gcc-runtime.require[0]` - it does not have to be a `@VERSION` as it dynamically creates it's version. That way, we can still put compiler constraints on the package without having to specify a version as the first element.
+
 ## 1-0-5
 
 * Updated `spack.specs` to allow > 1 specs allowed. The first spec is still used as a basis for deployment information.

--- a/au.org.access-nri/model/spack/environment/deployment/CHANGELOG.md
+++ b/au.org.access-nri/model/spack/environment/deployment/CHANGELOG.md
@@ -2,7 +2,15 @@
 
 ## 1-0-6
 
-* Added special case for `spack.packages.gcc-runtime.require[0]` - it does not have to be a `@VERSION` as it dynamically creates it's version. That way, we can still put compiler constraints on the package without having to specify a version as the first element.
+* Added special case for `spack.packages.gcc-runtime.require[0]` - it does not have to be a `@VERSION` as it dynamically creates it's version. That way, we can still put compiler constraints on the package without having to specify a version as the first element. For example:
+
+```yaml
+spack:
+  packages:
+    gcc-runtime:
+      requires:
+        - '%gcc@8.5.0'  # Note, not a '@VERSION'
+```
 
 ## 1-0-5
 


### PR DESCRIPTION
## Background

Since we need to set `gcc-runtime`s compiler, but not the version (and indeed, the version for this package is generated dynamically (probably based on the compiler version)), we need to special case the `gcc-runtime` package to not be constrained by the `...requires[0] == @VERSION` check. I hope this is the only instance of the special case...

## The PR

Actual schema changes are in https://github.com/ACCESS-NRI/schema/pull/44/commits/c5ab8f5f17f575729fbb45887eb3442a69b54d3b

In this PR:

- **Add 1-0-6.json based on 1-0-5.json**
- **Add in special case for dynamically-versioned `gcc-runtime` package**
- **Update Changelog**

## Testing

Tested on https://github.com/ACCESS-NRI/ACCESS-OM3/blob/oneapi-test/spack.yaml with the first `gcc-runtime` requirement removed, using `ajv`: `ajv -d spack.yaml -s au.org.access-nri/model/spack/deployment/1-0-6.json`
