### PR TITLE
Allow `@latest` for `spack.specs[0]`

### DIFF
--- a/au.org.access-nri/model/spack/environment/deployment/1-0-7.json
+++ b/au.org.access-nri/model/spack/environment/deployment/1-0-7.json
@@ -76,7 +76,7 @@
             "minItems": 1,
             "items": {
               "type": "string",
-              "pattern": "^.+@git\\.[^= ]+.*$|\\$ROOT_SPEC"
+              "pattern": "^.+@git\\.[^= ]+.*$|\\$ROOT_SPEC|^.+@latest"
             }
           },
           "definitions": {

--- a/au.org.access-nri/model/spack/environment/deployment/1-0-7.json
+++ b/au.org.access-nri/model/spack/environment/deployment/1-0-7.json
@@ -1,0 +1,170 @@
+{
+    "$id": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/spack/environment/deployment/1-0-7.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Restricted spack environment file schema for ACCESS-NRI continuous deployment",
+    "description": "This schema was adapted from https://github.com/ACCESS-NRI/spack/blob/releases/v0.21/lib/spack/spack/schema/env.py to specify a restricted form of spack.yaml to design generic deployment infrastructure.",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "spack": {
+        "type": "object",
+        "default": {},
+        "additionalProperties": true,
+        "properties": {
+          "packages": {
+            "type": "object",
+            "default": {},
+            "additionalProperties": true,
+            "properties": {
+              "gcc-runtime": {
+                "type": "object",
+                "default": {},
+                "additionalProperties": true,
+                "properties": {
+                  "require": {
+                    "type": "array",
+                    "minItems": 1,
+                    "additionalItems": true,
+                    "items": {
+                      "oneOf": [
+                        {
+                          "type": "object"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "patternProperties": {
+              "(?!^(all|gcc-runtime)$)(^\\w[\\w-]*)": {
+                "type": "object",
+                "default": {},
+                "additionalProperties": true,
+                "properties": {
+                  "require": {
+                    "type": "array",
+                    "minItems": 1,
+                    "additionalItems": true,
+                    "items": [
+                      {
+                        "type": "string",
+                        "pattern": "^@[A-Za-z0-9.\\-_=\/]+$"
+                      },
+                      {
+                        "oneOf": [
+                          {
+                            "type": "object"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "specs": {
+            "type": "array",
+            "default": [],
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "pattern": "^.+@git\\.[^= ]+.*$|\\$ROOT_SPEC"
+            }
+          },
+          "definitions": {
+            "type": "array",
+            "default": [],
+            "items": {
+              "type": "object",
+              "properties": {
+                "when": {
+                  "type": "string"
+                },
+                "ROOT_PACKAGE": {
+                  "type": "array",
+                  "minItems": 1,
+                  "maxItems": 1,
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "ROOT_SPEC": {
+                  "type": "array",
+                  "items": {
+                    "type":"object",
+                    "properties": {
+                      "matrix": {
+                        "type": "array",
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "exclude": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "if": {
+      "properties": {
+        "spack": {
+          "type": "object",
+          "properties": {
+            "specs": {
+              "type": "array",
+              "contains": {
+                "const": "$ROOT_SPEC"
+              }
+            }
+          }
+        }
+      }
+    },
+    "then": {
+      "properties": {
+        "spack": {
+          "type": "object",
+          "properties": {
+            "definitions": {
+              "allOf": [
+                {
+                  "type": "array",
+                  "contains": {
+                    "type": "object",
+                    "required": ["ROOT_SPEC"]
+                  }
+                },
+                {
+                  "type": "array",
+                  "contains": {
+                    "type": "object",
+                    "required": ["ROOT_PACKAGE"]
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  }

--- a/au.org.access-nri/model/spack/environment/deployment/CHANGELOG.md
+++ b/au.org.access-nri/model/spack/environment/deployment/CHANGELOG.md
@@ -1,5 +1,11 @@
 # `spack.yaml` Schema Changelog
 
+## 1-0-7
+
+* Allow the use of `@latest` in `spack.specs[0]`. This is allowed for Prereleases, but not for Releases. This keeps continuity with local builds which can't use not-yet-existing `@git.TAG`s like Prerelease builds can.
+
+This has full interoperability with the earlier schema/data.
+
 ## 1-0-6
 
 * Added special case for `spack.packages.gcc-runtime.require[0]` - it does not have to be a `@VERSION` as it dynamically creates it's version. That way, we can still put compiler constraints on the package without having to specify a version as the first element. For example:
@@ -11,6 +17,8 @@ spack:
       requires:
         - '%gcc@8.5.0'  # Note, not a '@VERSION'
 ```
+
+This has full interoperability with the earlier schema/data.
 
 ## 1-0-5
 


### PR DESCRIPTION
References ACCESS-NRI/build-cd#234

## Background

Local `spack` builds using a `spack.yaml` need to use `@latest` because they can't reference a not-yet-existing `@git.TAG` like prerelease builds can. To allow continuity between these types, allow `@latest` in the schema. 

## The PR

In this PR:

- **Add 1-0-7.json**
- **Allow `@latest` as a ref**
- **Update CHANGELOG**
