### PR TITLE
Tracking Services: Release Provenance Payload Schema

### DIFF
--- a/au.org.access-nri/tracking_services/release_provenance/telemetry/1-0-0.json
+++ b/au.org.access-nri/tracking_services/release_provenance/telemetry/1-0-0.json
@@ -1,0 +1,140 @@
+{
+    "$id": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/tracking_services/release_provenance/telemetry/1-0-0.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Telemetry data for release provenance",
+    "description": "Schema for JSON payload sent to tracking_services release_provenance database",
+    "type": "object",
+    "properties": {
+      "service": {
+        "type": "string"
+      },
+      "version": {
+        "type": "string"
+      },
+      "telemetry": {
+        "type": "object",
+        "properties": {
+          "model.name": {
+            "type": "string"
+          },
+          "model.deployment_repository_url": {
+            "type": "string"
+          },
+          "model.hive_docs_url": {
+            "type": "string"
+          },
+          "model_deployment.version": {
+            "type": "string"
+          },
+          "model_deployment.status": {
+            "type": "string"
+          },
+          "model_deployment.released_at": {
+            "type": "string"
+          },
+          "model_deployment.release_url": {
+            "type": "string"
+          },
+          "deployment_targets": {
+            "type": "array",
+            "items": [
+              {
+                "type": "object",
+                "properties": {
+                  "deployment_target.name": {
+                    "type": "string"
+                  },
+                  "deployment_target.spack_version": {
+                    "type": "string"
+                  },
+                  "deployment_target.spack_git_hash": {
+                    "type": "string"
+                  },
+                  "deployment_target.spack_config_version": {
+                    "type": "string"
+                  },
+                  "deployment_target.spack_config_git_hash": {
+                    "type": "string"
+                  },
+                  "deployment_target.spack_packages_version": {
+                    "type": "string"
+                  },
+                  "deployment_target.spack_packages_git_hash": {
+                    "type": "string"
+                  },
+                  "deployment_target.module_load_location": {
+                    "type": "string"
+                  },
+                  "spack_model.name": {
+                    "type": "string"
+                  },
+                  "spack_model.spack_package_hash": {
+                    "type": "string"
+                  },
+                  "spack_model.module_use_command": {
+                    "type": "string"
+                  },
+                  "spack_model_components": {
+                    "type": "array",
+                    "items": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "spack_package_hash": {
+                            "type": "string"
+                          },
+                          "version": {
+                            "type": "string"
+                          },
+                          "install_location": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "spack_package_hash",
+                          "version",
+                          "install_location"
+                        ]
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "deployment_target.name",
+                  "deployment_target.spack_version",
+                  "deployment_target.spack_git_hash",
+                  "deployment_target.spack_config_version",
+                  "deployment_target.spack_config_git_hash",
+                  "deployment_target.spack_packages_version",
+                  "deployment_target.spack_packages_git_hash",
+                  "deployment_target.module_load_location",
+                  "spack_model.name",
+                  "spack_model.spack_package_hash",
+                  "spack_model.module_use_command",
+                  "spack_model_components"
+                ]
+              }
+            ]
+          }
+        },
+        "required": [
+          "model.name",
+          "model.deployment_repository_url",
+          "model_deployment.version",
+          "model_deployment.status",
+          "model_deployment.released_at",
+          "model_deployment.release_url",
+          "deployment_targets"
+        ]
+      }
+    },
+    "required": [
+      "service",
+      "version",
+      "telemetry"
+    ]
+  }

--- a/au.org.access-nri/tracking_services/release_provenance/telemetry/CHANGELOG.md
+++ b/au.org.access-nri/tracking_services/release_provenance/telemetry/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Telemetry for Release Provenance DB Schema Changelog
+
+## 1-0-0
+
+* Initial release

--- a/au.org.access-nri/tracking_services/release_provenance/telemetry/README.md
+++ b/au.org.access-nri/tracking_services/release_provenance/telemetry/README.md
@@ -1,0 +1,14 @@
+# Telemetry for Release Provenance DB Schema
+
+This schema is used to validate the json data posted to `tracking_services` `release_provenance` app.
+
+## Extending the schema
+
+To modify the schema, a new version of the schema will need to be created.
+
+1. Determine the new schema version: We utilize [`SchemaVer`](https://docs.snowplow.io/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver/) for schema versioning. In a nutshell, `SchemaVer` is a `MODEL-REVISION-ADDITION` format, where:
+    * If adding changes that have no interoperability with the previous schema or historical data, the `MODEL` version should be incremented.
+    * If adding changes that may have interoperability with the previous schema and some historical data, increment the `REVISION` version.
+    * If adding changes that are interoperable with the previous schema and all historical data, increment the `ADDITION` version.
+
+2. Create a new file for the new schema version, e.g. `1-0-1.json`


### PR DESCRIPTION
Related to ACCESS-NRI/build-cd#263

Producer in progress at https://github.com/ACCESS-NRI/build-cd/tree/263-release-provenance-2.0
Consumer in https://github.com/ACCESS-NRI/tracking-services/pull/33

## Background

It would be useful to standardize on what data is produced and consumed relating to the release provenance database in a neutral third repository, so each side can validate it. This PR creates a first pass at the expected payload. 

## The PR

* Add `1-0-0.json`, changelog and README.md
