### PR TITLE
Update 1-0-0 before use: Swap module use/load

### DIFF
--- a/au.org.access-nri/tracking_services/release_provenance/telemetry/1-0-0.json
+++ b/au.org.access-nri/tracking_services/release_provenance/telemetry/1-0-0.json
@@ -62,7 +62,7 @@
                   "deployment_target.spack_packages_git_hash": {
                     "type": "string"
                   },
-                  "deployment_target.module_load_location": {
+                  "deployment_target.module_use_location": {
                     "type": "string"
                   },
                   "spack_model.name": {
@@ -71,7 +71,7 @@
                   "spack_model.spack_package_hash": {
                     "type": "string"
                   },
-                  "spack_model.module_use_command": {
+                  "spack_model.module_load_command": {
                     "type": "string"
                   },
                   "spack_model_components": {


### PR DESCRIPTION
## Background

I'd erroneously had the module use/module load commands under the wrong database models. I've ninja edited the original `1-0-0` schema before we use it in production. 

## The PR

* Swap `module use` and `module load` fields. 

