### PR TITLE
Add required repository_url to model component

### DIFF
--- a/au.org.access-nri/tracking_services/release_provenance/telemetry/1-0-0.json
+++ b/au.org.access-nri/tracking_services/release_provenance/telemetry/1-0-0.json
@@ -91,13 +91,17 @@
                           },
                           "install_location": {
                             "type": "string"
+                          },
+                          "repository_url": {
+                            "type": "string"
                           }
                         },
                         "required": [
                           "name",
                           "spack_package_hash",
                           "version",
-                          "install_location"
+                          "install_location",
+                          "repository_url"
                         ]
                       }
                     ]


### PR DESCRIPTION
The old database kept track of URLs to the model components -  this should be the case for the current one, too. 