### PR TITLE
Add initial schema for MDRs `config/auto-configs-pr.json`

### DIFF
--- a/au.org.access-nri/model/deployment/config/auto-configs-pr/1-0-0.json
+++ b/au.org.access-nri/model/deployment/config/auto-configs-pr/1-0-0.json
@@ -1,0 +1,68 @@
+{
+  "$id": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/auto-configs-pr/1-0-0.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Schema for MDR config/auto-configs-pr.json files",
+  "description": "This schema is used to configure the creation of model configuration repository Pull Requests from Prerelease builds of Climate Models",
+
+  "definitions": {
+    "profile": {
+      "type": "object",
+      "properties": {
+        "configs_repo": {
+          "type": "string",
+          "description": "OWNER/REPO-formatted repository where model configurations are stored.",
+          "pattern": "^[^/]+/[^/]+$"
+        },
+        "configs": {
+          "type": "object",
+          "description": "Configs within this profile keyed by config name.",
+          "patternProperties": {
+            "^[a-zA-Z0-9._-]+$": {
+              "type": "object",
+              "properties": {
+                "checks": {
+                  "type": "object",
+                  "properties": {
+                    "repro": {
+                      "type": "boolean",
+                      "description": "Indicates whether repro checking is required for this configuration."
+                    }
+                  },
+                  "required": ["repro"],
+                  "additionalProperties": false
+                }
+              },
+              "required": ["checks"],
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "required": ["configs_repo", "configs"],
+      "additionalProperties": false
+    }
+  },
+
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "const": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/auto-configs-pr/1-0-0.json"
+    },
+    "profiles": {
+      "type": "object",
+      "description": "Collection of model configuration profiles keyed by profile name.",
+      "properties": {
+        "default": { "$ref": "#/definitions/profile" }
+      },
+      "patternProperties": {
+        "^(?!default$)[a-zA-Z0-9._-]+$": { "$ref": "#/definitions/profile" }
+      },
+      "required:": ["default"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["profiles"],
+  "additionalProperties": false
+}

--- a/au.org.access-nri/model/deployment/config/auto-configs-pr/1-0-0.json
+++ b/au.org.access-nri/model/deployment/config/auto-configs-pr/1-0-0.json
@@ -59,7 +59,7 @@
       "patternProperties": {
         "^(?!default$)[a-zA-Z0-9._-]+$": { "$ref": "#/definitions/profile" }
       },
-      "required:": ["default"],
+      "required": ["default"],
       "additionalProperties": false
     }
   },

--- a/au.org.access-nri/model/deployment/config/auto-configs-pr/CHANGELOG.md
+++ b/au.org.access-nri/model/deployment/config/auto-configs-pr/CHANGELOG.md
@@ -1,0 +1,7 @@
+# MDR `config/auto-configs-pr.json` Schema Changelog
+
+## 1-0-0
+
+* Initial release
+* Allows a set of different model configuration *profiles* which contain model configurations to open PRs for (and optionally run repro checks against) for a given model configurations repository.
+* Requires a `default` profile to be specified

--- a/au.org.access-nri/model/deployment/config/auto-configs-pr/README.md
+++ b/au.org.access-nri/model/deployment/config/auto-configs-pr/README.md
@@ -1,0 +1,16 @@
+# MDR `config/auto-configs-pr.json` Schema
+
+This schema is used to validate the `config/auto-configs-pr.json` file in an MDR.
+
+That file is used to configure the automatic opening of Model Configuration Repository Pull Requests via a `!configs` comment command in the MDR.
+
+## Extending the schema
+
+To modify the schema, a new version of the schema will need to be created.
+
+1. Determine the new schema version: We utilize [`SchemaVer`](https://docs.snowplow.io/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver/) for schema versioning. In a nutshell, `SchemaVer` is a `MODEL-REVISION-ADDITION` format, where:
+    * If adding changes that have no interoperability with the previous schema or historical data, the `MODEL` version should be incremented.
+    * If adding changes that may have interoperability with the previous schema and some historical data, increment the `REVISION` version.
+    * If adding changes that are interoperable with the previous schema and all historical data, increment the `ADDITION` version.
+
+2. Create a new file for the new schema version, e.g. `1-0-1.json`


### PR DESCRIPTION
References ACCESS-NRI/build-cd#320

## Background

We need a schema to validate the MDRs `config/auto-configs-pr.json` configuration file, which is used to inform what PRs are opened from a given prerelease build. 

## The PR

* Added initial schema, CHANGELOG and README

## Testing

Validated against the example below with `jsonschema -i test.json au.org.access-nri/model/deployment/config/auto-configs-pr/1-0-0.json`:

```json
{
  "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/auto-configs-pr/1-0-0.json",
  "profiles": {

    "default": {
      "configs_repo": "ACCESS-NRI/access-test-configs",
      "configs": {
        "dev-01deg_jra55_iaf": {
          "checks": {
            "repro": true
          }
        },
        "dev-01deg_jra55_ryf": {
          "checks": {
            "repro": false
          }
        }
      }
    },

    "qa-only": {
      "configs_repo": "ACCESS-NRI/access-test-configs",
      "configs": {
        "dev-01deg_jra55_iaf": {
          "checks": {
            "repro": false
          }
        },
        "dev-01deg_jra55_ryf": {
          "checks": {
            "repro": false
          }
        }
      }
    }
  }
}
``` 
