### PR TITLE
ESM1.6 output file schema

### DIFF
--- a/.github/actions/schema-ci.yml
+++ b/.github/actions/schema-ci.yml
@@ -1,0 +1,28 @@
+name: JSON Schema CI
+
+on: [pull_request, workflow_dispatch]
+
+env:
+  SCHEMA_DIR: au.org.access-nri/model/output/file-metadata/2-0-0
+  TEST_DIR: au.org.access-nri/tests
+
+jobs:
+  schema-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install the Sourcemeta JSON Schema CLI
+        uses: sourcemeta/jsonschema@v11.8.3
+
+      - name: Check schemas against their metaschemas
+        run: jsonschema metaschema --verbose $SCHEMA_DIR
+
+      - name: Check schemas are formatted
+        run: jsonschema fmt --check --verbose $SCHEMA_DIR
+
+      - name: Lint schemas
+        run: jsonschema lint --verbose $SCHEMA_DIR
+
+      - name: Run test suite
+        run: jsonschema test --verbose $TEST_DIR --resolve $SCHEMA_DIR

--- a/au.org.access-nri/model/output/file-metadata/2-0-0/2-0-0.json
+++ b/au.org.access-nri/model/output/file-metadata/2-0-0/2-0-0.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/output/file-metadata/2-0-0/2-0-0.json",
+  "title": "ACCESS ESM1.6 Model Output Data Specification",
+  "description": "The metadata associated with a file containing or referencing climate model data",
+  "type": "object",
+  "required": [ "global" ],
+  "properties": {
+    "global": {
+      "$ref": "global.json"
+    }
+  }
+}

--- a/au.org.access-nri/model/output/file-metadata/2-0-0/global.json
+++ b/au.org.access-nri/model/output/file-metadata/2-0-0/global.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "global.json",
+  "title": "ACCESS Global Attributes",
+  "description": "File-level metadata for ACCESS ESM1.6 data",
+  "type": "object",
+  "required": [
+    "title",
+    "experiment_uuid",
+    "run_id",
+    "creation_date",
+    "realm",
+    "model",
+    "model_version",
+    "base_configuration",
+    "experiment_url",
+    "frequency",
+    "grid",
+    "Conventions",
+    "licence",
+    "contact",
+    "data_specification",
+    "_IsNetcdf4",
+    "_Format"
+  ],
+  "properties": {
+    "title": {
+      "$ref": "global/title.json"
+    },
+    "Conventions": {
+      "$ref": "global/Conventions.json"
+    },
+    "_Format": {
+      "$ref": "global/_Format.json"
+    },
+    "_IsNetcdf4": {
+      "$ref": "global/_IsNetcdf4.json"
+    },
+    "base_configuration": {
+      "$ref": "global/base_configuration.json"
+    },
+    "contact": {
+      "$ref": "global/contact.json"
+    },
+    "creation_date": {
+      "$ref": "global/creation_date.json"
+    },
+    "data_specification": {
+      "$ref": "global/data_specification.json"
+    },
+    "experiment_url": {
+      "$ref": "global/experiment_url.json"
+    },
+    "experiment_uuid": {
+      "$ref": "global/uuid.json"
+    },
+    "frequency": {
+      "$ref": "global/frequency.json"
+    },
+    "grid": {
+      "$ref": "global/grid.json"
+    },
+    "licence": {
+      "$ref": "global/licence.json"
+    },
+    "model": {
+      "$ref": "global/model.json"
+    },
+    "model_version": {
+      "$ref": "global/model_version.json"
+    },
+    "realm": {
+      "$ref": "global/realm.json"
+    },
+    "run_id": {
+      "$ref": "global/run_id.json"
+    }
+  }
+}

--- a/au.org.access-nri/model/output/file-metadata/2-0-0/global/Conventions.json
+++ b/au.org.access-nri/model/output/file-metadata/2-0-0/global/Conventions.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "global/Conventions.json",
+  "title": "Conventions",
+  "description": "Convention(s) used with their versions, as a comma separated list",
+  "examples": [ "CF-1.11" ],
+  "type": "string"
+}

--- a/au.org.access-nri/model/output/file-metadata/2-0-0/global/_Format.json
+++ b/au.org.access-nri/model/output/file-metadata/2-0-0/global/_Format.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "global/_Format.json",
+  "title": "_Format",
+  "description": "Details on the netCDF format used",
+  "examples": [
+    "classic",
+    "64-bit offset",
+    "netCDF-4",
+    "netCDF-4 classic model"
+  ],
+  "type": "string"
+}

--- a/au.org.access-nri/model/output/file-metadata/2-0-0/global/_IsNetcdf4.json
+++ b/au.org.access-nri/model/output/file-metadata/2-0-0/global/_IsNetcdf4.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "global/_IsNetcdf4.json",
+  "title": "_IsNetcdf4",
+  "description": "DESCRIPTION",
+  "examples": [ "yes" ],
+  "type": "string"
+}

--- a/au.org.access-nri/model/output/file-metadata/2-0-0/global/base_configuration.json
+++ b/au.org.access-nri/model/output/file-metadata/2-0-0/global/base_configuration.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "global/base_configuration.json",
+  "title": "base_configuration",
+  "description": "Base configuration used - MORE INFO?",
+  "examples": [ "release-preindustrial+concentrations-2.0" ],
+  "type": "string"
+}

--- a/au.org.access-nri/model/output/file-metadata/2-0-0/global/contact.json
+++ b/au.org.access-nri/model/output/file-metadata/2-0-0/global/contact.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "global/contact.json",
+  "title": "contact",
+  "description": "Email address of the contact for the data",
+  "examples": [ "data.access.nri@anu.edu.au" ],
+  "type": "string",
+  "pattern": "\\b[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}\\b"
+}

--- a/au.org.access-nri/model/output/file-metadata/2-0-0/global/creation_date.json
+++ b/au.org.access-nri/model/output/file-metadata/2-0-0/global/creation_date.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "global/creation_date.json",
+  "title": "creation_date",
+  "description": "Date the file was created",
+  "$comment": "Formatted as YYYY-MM-DD",
+  "examples": [ "2025-08-12" ],
+  "pattern": "^\\d{4}-(1[012]|0[1-9])-(3[01]|[12][0-9]|0[1-9])$"
+}

--- a/au.org.access-nri/model/output/file-metadata/2-0-0/global/data_specification.json
+++ b/au.org.access-nri/model/output/file-metadata/2-0-0/global/data_specification.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "global/data_specification.json",
+  "title": "data_specification",
+  "description": "Version of this data specification used to generate the data",
+  "examples": [ "ACCESS Output Data Specification v0.1 XX.XXXX/zenodo.XXXXX" ],
+  "type": "string"
+}

--- a/au.org.access-nri/model/output/file-metadata/2-0-0/global/experiment_url.json
+++ b/au.org.access-nri/model/output/file-metadata/2-0-0/global/experiment_url.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "global/experiment_url.json",
+  "title": "experiment_url",
+  "description": "Git repository URL that describes the experiment",
+  "examples": [],
+  "type": "string"
+}

--- a/au.org.access-nri/model/output/file-metadata/2-0-0/global/frequency.json
+++ b/au.org.access-nri/model/output/file-metadata/2-0-0/global/frequency.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "global/frequency.json",
+  "title": "frequency",
+  "description": "Sampling frequency of the data",
+  "examples": [ "12hr", "1day", "1yr" ],
+  "type": "string",
+  "oneOf": [
+    {
+      "pattern": "^fx$"
+    },
+    {
+      "pattern": "^subhr$"
+    },
+    {
+      "pattern": "^\\d+hr$"
+    },
+    {
+      "pattern": "^\\d+day$"
+    },
+    {
+      "pattern": "^\\d+mon$"
+    },
+    {
+      "pattern": "^\\d+yr$"
+    },
+    {
+      "pattern": "^\\d+dec$"
+    }
+  ]
+}

--- a/au.org.access-nri/model/output/file-metadata/2-0-0/global/grid.json
+++ b/au.org.access-nri/model/output/file-metadata/2-0-0/global/grid.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "global/grid.json",
+  "title": "grid",
+  "description": "Brief description of output grid characteristics",
+  "examples": [],
+  "type": "string"
+}

--- a/au.org.access-nri/model/output/file-metadata/2-0-0/global/licence.json
+++ b/au.org.access-nri/model/output/file-metadata/2-0-0/global/licence.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "global/licence.json",
+  "title": "licence",
+  "description": "Information on the licence for the data to ensure all users have access to the terms of use",
+  "examples": [ "CC-BY-4.0" ],
+  "type": "string"
+}

--- a/au.org.access-nri/model/output/file-metadata/2-0-0/global/model.json
+++ b/au.org.access-nri/model/output/file-metadata/2-0-0/global/model.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "global/model.json",
+  "title": "model",
+  "description": "Name of the model used to create the data",
+  "examples": [ "ACCESS-ESM1.6" ],
+  "type": "string"
+}

--- a/au.org.access-nri/model/output/file-metadata/2-0-0/global/model_version.json
+++ b/au.org.access-nri/model/output/file-metadata/2-0-0/global/model_version.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "global/model_version.json",
+  "title": "model_version",
+  "description": "Version of the model used to create the data",
+  "$comment": "Use 'unknown if not an official release",
+  "examples": [ "2025.06.001" ],
+  "type": "string"
+}

--- a/au.org.access-nri/model/output/file-metadata/2-0-0/global/realm.json
+++ b/au.org.access-nri/model/output/file-metadata/2-0-0/global/realm.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "global/realm.json",
+  "title": "realm",
+  "description": "Realm(s) where the variable is defined, as a comma separated list",
+  "$comment": "This will probably be a string not an array. Currently spec allows one or more elements...",
+  "type": "array",
+  "minItems": 1,
+  "uniqueItems": true,
+  "items": {
+    "enum": [
+      "aerosol",
+      "atmos",
+      "atmosChem",
+      "land",
+      "landIce",
+      "ocean",
+      "ocnBgchem",
+      "seaIce"
+    ]
+  }
+}

--- a/au.org.access-nri/model/output/file-metadata/2-0-0/global/run_id.json
+++ b/au.org.access-nri/model/output/file-metadata/2-0-0/global/run_id.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "global/run_id.json",
+  "title": "run_id",
+  "description": "Git hash for the commit associated with the experiment run",
+  "$comment": "TBC long hash or short hash or either?",
+  "examples": [ "6a18f2514cf281bf9b47972e45a33743ec0e5962" ],
+  "type": "string"
+}

--- a/au.org.access-nri/model/output/file-metadata/2-0-0/global/title.json
+++ b/au.org.access-nri/model/output/file-metadata/2-0-0/global/title.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "global/title.json",
+  "title": "title",
+  "description": "Name of the dataset",
+  "type": "string"
+}

--- a/au.org.access-nri/model/output/file-metadata/2-0-0/global/uuid.json
+++ b/au.org.access-nri/model/output/file-metadata/2-0-0/global/uuid.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "global/uuid.json",
+  "title": "uuid",
+  "description": "The uniquie UUID for the experiment",
+  "type": "string"
+}

--- a/au.org.access-nri/tests/test.json
+++ b/au.org.access-nri/tests/test.json
@@ -1,0 +1,35 @@
+{
+    "target": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/output/file-metadata/2-0-0/2-0-0.json",
+    "tests": [
+        {
+            "description": "Full ESM1.6",
+            "valid": true,
+            "data": {
+                "global": {
+                    "title": "this is a title",
+                    "experiment_uuid": "F6B536FA-766D-4609-B767-754C9424440A",
+                    "run_id": "git hash?",
+                    "creation_date": "2025-12-03",
+                    "realm": ["atmos"],
+                    "model": "ACCESS-ESM1.6",
+                    "model_version": "2025.06.001",
+                    "base_configuration": "release-preindustrial+concentrations-2.0",
+                    "experiment_url": "x",
+                    "frequency": "1hr",
+                    "grid": "grid goes here",
+                    "Conventions": "CF-1.11",
+                    "licence": "CC-BY-4.0",
+                    "contact": "data.access.nri@anu.edu.au",
+                    "data_specification": "ACCESS Output Data Specification v0.1 XX.XXXX/zenodo.XXXXX",
+                    "_IsNetcdf4": "yes",
+                    "_Format": "netCDF-4"
+                }
+            }
+        },
+        {
+            "description": "Empty",
+            "valid": false,
+            "data": {}
+        }
+    ]
+}


### PR DESCRIPTION
As part of the under-development ESM1.6 model output specification I have a new draft of the new schema in a new branch and I'm contemplating adding some more CI checks for the schema.

I'm attempting to draft the new version of the schema with multiple files to hopefully simplify the specification and allow for easy changes in the future.

Still To do:
- [ ] Check relative references/ids work as intended in a github repo particularly with tests etc. (they work locally...)
- [ ] What should the new version of the schema be? Likely `2-0-0` or `1-1-0`
- [ ] What extra CI can/should be added?
  - [ ] json schema metavalidater, linter, formatter, tests
  - [ ] I wasn't able to get pre-commit autoformatting working in my initial tests so it's just a CI test at the moment
  - [ ] Get CI working as desired
  - [ ] Does the new CI pass on the old schemas? Can we just run it over all schema or just the new?
- [ ] Is there a way to support schema versions using git commits/tags/releases/something rather than duplicate files in the repo?
  - [ ] Should the version of the schema be mentioned in each schema/sub-schema file?
- [ ] details of global metadata schema need reviewing
  - [ ] `realm` should be simplified to a single `realm`
  - [ ] `creation_date` needs renaming to a more standard name
  - [ ] What else?
- [ ] variable metadata
  - [ ] Can this be defined with a unknown variable name?
  - [ ] Make nothing required since we don't know if a given .nc variable is a coordinate or data?
- [ ] Build auto-generating user docs from schema (likely in [this](https://github.com/ACCESS-NRI/ACCESS_Output_data_specifications) repo)