### PR TITLE
MDR `config/versions.json`: Optional `custom-scopes` Field

### DIFF
--- a/au.org.access-nri/model/deployment/config/versions/4-0-0.json
+++ b/au.org.access-nri/model/deployment/config/versions/4-0-0.json
@@ -13,6 +13,12 @@
         },
         "access-spack-packages": {
             "type": "string"
+        },
+        "custom-scopes": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
         }
     },
     "required": [ "$schema", "spack", "access-spack-packages" ],

--- a/au.org.access-nri/model/deployment/config/versions/CHANGELOG.md
+++ b/au.org.access-nri/model/deployment/config/versions/CHANGELOG.md
@@ -15,3 +15,4 @@
 ## 4-0-0
 
 * Updated `spack-packages` to `access-spack-packages` to demarcate it from the new, required `builtin-spack-packages` in `build-cd`s `config/settings.json`. This means it's not interoperable with historical data.
+* Also added an optional `custom-scopes` array for modifying `spack install` scopes from `spack-config`s `custom/cd` directory.


### PR DESCRIPTION
References ACCESS-NRI/build-cd#334, ACCESS-NRI/build-cd#335

## Background

Rather than putting custom config logic in MDRs, we should be able to use existing config scopes from `spack-config`s `custom/cd/SCOPE` directory. See the referenced issues/PRs for more info.

## The PR

* Updates the existing `4-0-0` MDR `config/versions.json` schema to include an optional `custom-scopes` array, to allow users to pick out custom scopes. 
