### PR TITLE
Typo in standard_name description

### DIFF
--- a/au.org.access-nri/model/output/file-metadata/2-0-0/variable/standard_name.json
+++ b/au.org.access-nri/model/output/file-metadata/2-0-0/variable/standard_name.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "variable/standard_name.json",
   "title": "standard_name",
-  "description": "Where posisble use the CF standard_name of the variable, otherwise use a unique short phrase separated by underscores to describe the variable.",
+  "description": "Where possible use the CF standard_name of the variable, otherwise use a unique short phrase separated by underscores to describe the variable.",
   "examples": [
     "air_pressure_at_sea_level",
     "latitude",


### PR DESCRIPTION
Simple correction of a typo in the description field for standard_name in the file output schema.