### PR TITLE
Update Actions to Node 24

### DIFF
--- a/.github/actions/validate-with-schema/action.yml
+++ b/.github/actions/validate-with-schema/action.yml
@@ -2,19 +2,15 @@ name: Validate With Schema
 description: Action that validates json/yaml data against a given schema
 inputs:
   schema-version:
-    type: string
     required: true
     description: Version of the schema required, in SchemaVer
   schema-location:
-    type: string
     required: true
     description: Directory within access-nri/schema that contains the schema
   data-location:
-    type: string
     required: true
     description: Path(s) to the data file(s) in the callers repository
   meta-schema-version:
-    type: string
     required: false
     default: draft-07
     description: |

--- a/.github/actions/validate-with-schema/action.yml
+++ b/.github/actions/validate-with-schema/action.yml
@@ -40,7 +40,7 @@ runs:
           ${{ inputs.schema-location }}/${{ inputs.schema-version }}.json
         sparse-checkout-cone-mode: false
 
-    - uses: GrantBirki/json-yaml-validate@d7814b94473939c1daaca2c96131b891d4703a3c # v2.7.1
+    - uses: GrantBirki/json-yaml-validate@d7814b94473939c1daaca2c96131b891d4703a3c # v5.0.0
       with:
         mode: fail
         files: |

--- a/.github/actions/validate-with-schema/action.yml
+++ b/.github/actions/validate-with-schema/action.yml
@@ -36,7 +36,7 @@ runs:
           ${{ inputs.schema-location }}/${{ inputs.schema-version }}.json
         sparse-checkout-cone-mode: false
 
-    - uses: GrantBirki/json-yaml-validate@d7814b94473939c1daaca2c96131b891d4703a3c # v5.0.0
+    - uses: GrantBirki/json-yaml-validate@3ff75979f3b21171f2e8a44705f0ff4bed30bbc0 # v5.0.0
       with:
         mode: fail
         files: |

--- a/.github/actions/validate-with-schema/action.yml
+++ b/.github/actions/validate-with-schema/action.yml
@@ -32,7 +32,7 @@ runs:
         fi
 
     # Checkout the `schema-repo`
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         repository: access-nri/schema
         path: schema

--- a/.github/workflows/schema-ci.yml
+++ b/.github/workflows/schema-ci.yml
@@ -20,7 +20,7 @@ jobs:
   schema-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install the Sourcemeta JSON Schema CLI
         uses: sourcemeta/jsonschema@f0b6672d82955e58a73efd320068284a4e7a4483 #v14.14.2
@@ -42,7 +42,7 @@ jobs:
       - name: Run test suite
         run: |
           # Need to iterate through each pair of DIRS since there will be name
-          # collisions with different versions of the same schema 
+          # collisions with different versions of the same schema
           # Turn the strings into arrays of strings first
           test_arr=($TEST_DIRS)
           schema_arr=($SCHEMA_DIRS)

--- a/.github/workflows/validate-schema.yml
+++ b/.github/workflows/validate-schema.yml
@@ -18,7 +18,7 @@ jobs:
     outputs:
       matrix: ${{ steps.changed.outputs.all_changed_files }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
@@ -41,7 +41,7 @@ jobs:
     env:
       METASCHEMA_PATH: schema.json
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/validate-schema.yml
+++ b/.github/workflows/validate-schema.yml
@@ -59,7 +59,7 @@ jobs:
           # Download the metaschema - Use -L to follow any redirects from http to https
           curl -L -o ${{ env.METASCHEMA_PATH }} $schema_url
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
 


### PR DESCRIPTION
See https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## The PR

- **Update actions/checkout to v6**
- **Update GrantBirki/json-yaml-validate to v5.0.0 (commit hash associated with that version)**
- **Remove unneeded input types for action**
