### PR TITLE
`!update-configs` Config Schema - Support Different Workflow Managers and HPCs

### DIFF
--- a/au.org.access-nri/model/deployment/config/auto-configs-pr/1-0-1.json
+++ b/au.org.access-nri/model/deployment/config/auto-configs-pr/1-0-1.json
@@ -19,6 +19,12 @@
           "description": "The workflow manager to use for this profile.",
           "enum": ["payu", "rose-cylc"]
         },
+        "target": {
+          "type": "string",
+          "default": "gadi",
+          "description": "The target HPC system for this profile.",
+          "enum": ["gadi"]
+        },
         "configs": {
           "type": "object",
           "description": "Configs within this profile keyed by config name.",

--- a/au.org.access-nri/model/deployment/config/auto-configs-pr/1-0-1.json
+++ b/au.org.access-nri/model/deployment/config/auto-configs-pr/1-0-1.json
@@ -1,0 +1,68 @@
+{
+  "$id": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/auto-configs-pr/1-0-0.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Schema for MDR config/auto-configs-pr.json files",
+  "description": "This schema is used to configure the creation of model configuration repository Pull Requests from Prerelease builds of Climate Models",
+
+  "definitions": {
+    "profile": {
+      "type": "object",
+      "properties": {
+        "configs_repo": {
+          "type": "string",
+          "description": "OWNER/REPO-formatted repository where model configurations are stored.",
+          "pattern": "^[^/]+/[^/]+$"
+        },
+        "configs": {
+          "type": "object",
+          "description": "Configs within this profile keyed by config name.",
+          "patternProperties": {
+            "^[a-zA-Z0-9._+-]+$": {
+              "type": "object",
+              "properties": {
+                "checks": {
+                  "type": "object",
+                  "properties": {
+                    "repro": {
+                      "type": "boolean",
+                      "description": "Indicates whether repro checking is required for this configuration."
+                    }
+                  },
+                  "required": ["repro"],
+                  "additionalProperties": false
+                }
+              },
+              "required": ["checks"],
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "required": ["configs_repo", "configs"],
+      "additionalProperties": false
+    }
+  },
+
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "const": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/auto-configs-pr/1-0-0.json"
+    },
+    "profiles": {
+      "type": "object",
+      "description": "Collection of model configuration profiles keyed by profile name.",
+      "properties": {
+        "default": { "$ref": "#/definitions/profile" }
+      },
+      "patternProperties": {
+        "^(?!default$)[a-zA-Z0-9._-]+$": { "$ref": "#/definitions/profile" }
+      },
+      "required": ["default"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["profiles"],
+  "additionalProperties": false
+}

--- a/au.org.access-nri/model/deployment/config/auto-configs-pr/1-0-1.json
+++ b/au.org.access-nri/model/deployment/config/auto-configs-pr/1-0-1.json
@@ -13,6 +13,12 @@
           "description": "OWNER/REPO-formatted repository where model configurations are stored.",
           "pattern": "^[^/]+/[^/]+$"
         },
+        "workflow_manager": {
+          "type": "string",
+          "default": "payu",
+          "description": "The workflow manager to use for this profile.",
+          "enum": ["payu", "rose-cylc"]
+        },
         "configs": {
           "type": "object",
           "description": "Configs within this profile keyed by config name.",

--- a/au.org.access-nri/model/deployment/config/auto-configs-pr/CHANGELOG.md
+++ b/au.org.access-nri/model/deployment/config/auto-configs-pr/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 1-0-1
 
-* Allows a profile to be associated with a particular workflow manager - currently only payu or rose-cylc.
+* Allows a profile to be associated with a particular workflow manager - currently only payu (default) or rose-cylc.
+* Allows a profile to be associated with a particular HPC target - currently only gadi (default).
 
 ## 1-0-0
 

--- a/au.org.access-nri/model/deployment/config/auto-configs-pr/CHANGELOG.md
+++ b/au.org.access-nri/model/deployment/config/auto-configs-pr/CHANGELOG.md
@@ -1,5 +1,9 @@
 # MDR `config/auto-configs-pr.json` Schema Changelog
 
+## 1-0-1
+
+* Allows a profile to be associated with a particular workflow manager - currently only payu or rose-cylc.
+
 ## 1-0-0
 
 * Initial release

--- a/au.org.access-nri/model/deployment/config/auto-configs-pr/README.md
+++ b/au.org.access-nri/model/deployment/config/auto-configs-pr/README.md
@@ -2,7 +2,7 @@
 
 This schema is used to validate the `config/auto-configs-pr.json` file in an MDR.
 
-That file is used to configure the automatic opening of Model Configuration Repository Pull Requests via a `!configs` comment command in the MDR.
+That file is used to configure the automatic opening of Model Configuration Repository Pull Requests via a `!update-configs` comment command in the MDR.
 
 ## Extending the schema
 


### PR DESCRIPTION
References ACCESS-NRI/build-cd#400

## Background

We need to be able to support non-`payu` configurations with `!update-configs`. This schema update supports an optional `workflow_manager` key in an MDRs `config/auto-configs-pr.json` file.

Furthermore, for future-proofing, we support an optional `target` field, currently defaulted to `gadi`.

## The PR

Diff between `1-0-0` and `1-0-1` in https://github.com/ACCESS-NRI/schema/pull/73/changes/713e45a2b71c2ce06e89c5d18aee53b8c51219f0

- **Add optional profiles.workflow_manager enum**
- **Add optional profiles.target enum**

## Testing

### Valid: No `workflow_manager` Specified

<details>

```yaml
{
  "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/auto-configs-pr/1-0-0.json",
  "profiles": {

    "default": {
      "configs_repo": "ACCESS-NRI/access-am3-configs",
      "configs": {
        "dev-n96e": {
          "checks": {
            "repro": true
          }
        }
      }
    }

  }
}
```
```bash
$ ajv -s schema/au.org.access-nri/model/deployment/config/auto-configs-pr/1-0-1.json -d ../ACCESS-AM3/config/auto-configs-pr.json 
../ACCESS-AM3/config/auto-configs-pr.json valid
```

</details>

### Valid: Supported `workflow_manager` Specified

<details>

```yaml
{
  "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/auto-configs-pr/1-0-0.json",
  "profiles": {

    "default": {
      "configs_repo": "ACCESS-NRI/access-am3-configs",
      "workflow_manager": "rose-cylc",
      "configs": {
        "dev-n96e": {
          "checks": {
            "repro": true
          }
        }
      }
    }

  }
}
```
```bash
$ ajv -s schema/au.org.access-nri/model/deployment/config/auto-configs-pr/1-0-1.json -d ../ACCESS-AM3/config/auto-configs-pr.json 
../ACCESS-AM3/config/auto-configs-pr.json valid
```

</details>

### Invalid: Unsupported `workflow_manager` Specified

<details>

```yaml
{
  "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/auto-configs-pr/1-0-0.json",
  "profiles": {

    "default": {
      "configs_repo": "ACCESS-NRI/access-am3-configs",
      "workflow_manager": "something-else",
      "configs": {
        "dev-n96e": {
          "checks": {
            "repro": true
          }
        }
      }
    }

  }
}
```
```bash
$ ajv -s schema/au.org.access-nri/model/deployment/config/auto-configs-pr/1-0-1.json -d ../ACCESS-AM3/config/auto-configs-pr.json 
../ACCESS-AM3/config/auto-configs-pr.json invalid
[
  {
    instancePath: '/profiles/default/workflow_manager',
    schemaPath: '#/definitions/profile/properties/workflow_manager/enum',
    keyword: 'enum',
    params: { allowedValues: [Array] },
    message: 'must be equal to one of the allowed values'
  }
]
```

</details>