### PR TITLE
Add parent model time in experiment-metadata.

### DIFF
--- a/au.org.access-nri/model/output/experiment-metadata/1-0-3.json
+++ b/au.org.access-nri/model/output/experiment-metadata/1-0-3.json
@@ -162,6 +162,10 @@
                 "type": ["string", "null"]
             },
             "description": "Keyword(s) associated with experiment (array of strings)"
+        },
+        "parent_branch_off_time": {
+            "type": ["string", "null"],
+            "description": "Model time in the parent experiment from which this experiment was branched (string)"
         }
     },
     "required": [


### PR DESCRIPTION
This PR adds a `parent_branch_off_time` field in metadata.yaml schema. This field records the model time of the parent experiment, when the new branch is created.

Closes #74 