### PR TITLE
Move SDR/MDR `config/` Into `spack.yaml` Schema Update

### DIFF
--- a/au.org.access-nri/model/deployment/config/packages/CHANGELOG.md
+++ b/au.org.access-nri/model/deployment/config/packages/CHANGELOG.md
@@ -4,3 +4,7 @@
 
 * Initial release
 * Added `provenance` and `injection` markers for packages
+
+## Deprecation
+
+This schema was deprecated for `build-cd@v9` and later, see the README.

--- a/au.org.access-nri/model/deployment/config/packages/README.md
+++ b/au.org.access-nri/model/deployment/config/packages/README.md
@@ -1,5 +1,8 @@
 # Deployment Special Packages Schema
 
+> [!IMPORTANT]
+> This schema is deprecated for MDR/SDRs using `build-cd@v9` or later, as that information is now in the `spack.yaml`. This config information is now in the [MDR `spack.yaml` schema](./../../../spack/environment/deployment/) from `3-0-0` onwards, or the [SDR `spack.yaml` schema](./../../../../tools/spack/environment/deployment/) from `2-0-0` onwards.
+
 This schema is used to mark certain packages as special in a model deployment repository.
 
 Currently we have to special marks:

--- a/au.org.access-nri/model/deployment/config/versions/CHANGELOG.md
+++ b/au.org.access-nri/model/deployment/config/versions/CHANGELOG.md
@@ -16,3 +16,7 @@
 
 * Updated `spack-packages` to `access-spack-packages` to demarcate it from the new, required `builtin-spack-packages` in `build-cd`s `config/settings.json`. This means it's not interoperable with historical data.
 * Also added an optional `custom-scopes` array for modifying `spack install` scopes from `spack-config`s `custom/cd` directory.
+
+## Deprecation
+
+This schema was deprecated for `build-cd@v9` and later, see the README.

--- a/au.org.access-nri/model/deployment/config/versions/README.md
+++ b/au.org.access-nri/model/deployment/config/versions/README.md
@@ -1,5 +1,8 @@
 # Deployment Packages Location Schema
 
+> [!IMPORTANT]
+> This schema is deprecated for MDR/SDRs using `build-cd@v9` or later, as that information is now in the `spack.yaml`. This config information is now in the [MDR `spack.yaml` schema](./../../../spack/environment/deployment/) from `3-0-0` onwards, or the [SDR `spack.yaml` schema](./../../../../tools/spack/environment/deployment/) from `2-0-0` onwards.
+
 This schema is used to specify versions of various repositories that are needed in the deployment of a specific model using `spack`.
 
 It is used in specific model repositories `config` directories, such as [ACCESS-NRI/ACCESS-OM2](https://github.com/ACCESS-NRI/ACCESS-OM2/tree/main/config).

--- a/au.org.access-nri/model/spack/environment/deployment/3-0-0.json
+++ b/au.org.access-nri/model/spack/environment/deployment/3-0-0.json
@@ -1,0 +1,202 @@
+{
+    "$id": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/spack/environment/deployment/2-0-0.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Restricted spack environment file schema for ACCESS-NRI continuous deployment",
+    "description": "This schema was adapted from https://github.com/ACCESS-NRI/spack/blob/releases/v0.21/lib/spack/spack/schema/env.py to specify a restricted form of spack.yaml to design generic deployment infrastructure.",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "spack": {
+        "type": "object",
+        "default": {},
+        "additionalProperties": true,
+        "properties": {
+          "packages": {
+            "type": "object",
+            "default": {},
+            "additionalProperties": true,
+            "properties": {
+              "gcc-runtime": {
+                "type": "object",
+                "default": {},
+                "additionalProperties": true,
+                "properties": {
+                  "require": {
+                    "type": "array",
+                    "minItems": 1,
+                    "additionalItems": true,
+                    "items": {
+                      "oneOf": [
+                        {
+                          "type": "object"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "patternProperties": {
+              "(?!^(all|gcc-runtime|c|cxx|fortran)$)(^\\w[\\w-]*)": {
+                "type": "object",
+                "default": {},
+                "additionalProperties": true,
+                "properties": {
+                  "require": {
+                    "type": "array",
+                    "minItems": 1,
+                    "additionalItems": true,
+                    "items": [
+                      {
+                        "type": "string",
+                        "pattern": "^@[A-Za-z0-9.\\-_=\/]+$"
+                      },
+                      {
+                        "oneOf": [
+                          {
+                            "type": "object"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "specs": {
+            "type": "array",
+            "default": [],
+            "minItems": 1,
+            "items": {
+              "type": "string"
+            }
+          },
+          "definitions": {
+            "type": "array",
+            "minItems": 2,
+            "allOf": [
+              {
+                "type": "array",
+                "contains": {
+                  "type": "object",
+                  "required": ["_name"],
+                  "properties": {
+                    "_name": {
+                      "type": "array",
+                      "minItems": 1,
+                      "maxItems": 1,
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "type": "array",
+                "contains": {
+                  "type": "object",
+                  "required": ["_version"],
+                  "properties": {
+                    "_name": {
+                      "type": "array",
+                      "minItems": 1,
+                      "maxItems": 1,
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "items": {
+              "type": "object",
+              "properties": {
+                "ROOT_PACKAGE": {
+                  "type": "array",
+                  "minItems": 1,
+                  "maxItems": 1,
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "ROOT_SPEC": {
+                  "type": "array",
+                  "items": {
+                    "type":"object",
+                    "properties": {
+                      "matrix": {
+                        "type": "array",
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "exclude": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "if": {
+      "properties": {
+        "spack": {
+          "type": "object",
+          "properties": {
+            "specs": {
+              "type": "array",
+              "contains": {
+                "const": "$ROOT_SPEC"
+              }
+            }
+          }
+        }
+      }
+    },
+    "then": {
+      "properties": {
+        "spack": {
+          "type": "object",
+          "properties": {
+            "definitions": {
+              "allOf": [
+                {
+                  "type": "array",
+                  "contains": {
+                    "type": "object",
+                    "required": ["ROOT_SPEC"]
+                  }
+                },
+                {
+                  "type": "array",
+                  "contains": {
+                    "type": "object",
+                    "required": ["ROOT_PACKAGE"]
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  }

--- a/au.org.access-nri/model/spack/environment/deployment/3-0-0.json
+++ b/au.org.access-nri/model/spack/environment/deployment/3-0-0.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/spack/environment/deployment/2-0-0.json",
+    "$id": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/spack/environment/deployment/3-0-0.json",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Restricted spack environment file schema for ACCESS-NRI continuous deployment",
     "description": "This schema was adapted from https://github.com/ACCESS-NRI/spack/blob/releases/v0.21/lib/spack/spack/schema/env.py to specify a restricted form of spack.yaml to design generic deployment infrastructure.",
@@ -11,6 +11,59 @@
         "default": {},
         "additionalProperties": true,
         "properties": {
+          "repos": {
+            "type": "object",
+            "default": {},
+            "additionalProperties": true,
+            "properties": {
+              "access_spack_packages": {
+                "type": "object",
+                "default": {},
+                "additionalProperties": false,
+                "properties": {
+                  "git": {
+                    "const": "https://github.com/ACCESS-NRI/access-spack-packages.git"
+                  },
+                  "tag": {
+                    "type": "string"
+                  },
+                  "branch": {
+                    "type": "string"
+                  },
+                  "commit": {
+                    "type": "string"
+                  },
+                  "destination": {
+                    "const": "$env/.package_repos/access-spack-packages"
+                  }
+                },
+                "required": [
+                  "git",
+                  "destination"
+                ],
+                "oneOf": [
+                  {
+                    "required": [
+                      "tag"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "branch"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "commit"
+                    ]
+                  }
+                ]
+              }
+            },
+            "required": [
+              "access_spack_packages"
+            ]
+          },
           "packages": {
             "type": "object",
             "default": {},
@@ -80,7 +133,7 @@
           },
           "definitions": {
             "type": "array",
-            "minItems": 2,
+            "minItems": 5,
             "allOf": [
               {
                 "type": "array",
@@ -109,6 +162,67 @@
                       "type": "array",
                       "minItems": 1,
                       "maxItems": 1,
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "type": "array",
+                "contains": {
+                  "type": "object",
+                  "required": ["_spack-version"],
+                  "properties": {
+                    "_spack-version": {
+                      "type": "array",
+                      "minItems": 1,
+                      "maxItems": 1,
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "type": "array",
+                "contains": {
+                  "type": "object",
+                  "required": ["_provenance"],
+                  "properties": {
+                    "_provenance": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "type": "array",
+                "contains": {
+                  "type": "object",
+                  "required": ["_injection"],
+                  "properties": {
+                    "_injection": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "type": "array",
+                "contains": {
+                  "type": "object",
+                  "properties": {
+                    "_custom-scopes": {
+                      "type": "array",
                       "items": {
                         "type": "string"
                       }

--- a/au.org.access-nri/model/spack/environment/deployment/3-0-0.json
+++ b/au.org.access-nri/model/spack/environment/deployment/3-0-0.json
@@ -78,16 +78,18 @@
                     "type": "array",
                     "minItems": 1,
                     "additionalItems": true,
-                    "items": {
-                      "oneOf": [
-                        {
-                          "type": "object"
-                        },
-                        {
-                          "type": "string"
-                        }
-                      ]
-                    }
+                    "items": [
+                      {
+                        "oneOf": [
+                          {
+                            "type": "object"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      }
+                    ]
                   }
                 }
               }

--- a/au.org.access-nri/model/spack/environment/deployment/CHANGELOG.md
+++ b/au.org.access-nri/model/spack/environment/deployment/CHANGELOG.md
@@ -1,5 +1,11 @@
 # `spack.yaml` Schema Changelog
 
+## 3-0-0
+
+* Require reserved definitions for `_spack-version`, `_provenance`, `_injection`
+* Require `spack.repos.access_spack_packages` section, with a constant `spack.repos.access_spack_packages.destination`
+* Optional reserved definition for `_custom-scopes`
+
 ## 2-0-0
 
 * Require reserved definitions for `spack.definitions[]._name` and `spack.definitions[]._version`

--- a/au.org.access-nri/tools/spack/environment/deployment/2-0-0.json
+++ b/au.org.access-nri/tools/spack/environment/deployment/2-0-0.json
@@ -1,0 +1,110 @@
+{
+    "$id": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/tools/spack/environment/deployment/1-0-0.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Restricted spack environment file schema for ACCESS-NRI continuous deployment (general software deployment)",
+    "description": "This schema was adapted from https://github.com/ACCESS-NRI/spack/blob/releases/v0.21/lib/spack/spack/schema/env.py to specify a restricted form of spack.yaml to design generic deployment infrastructure.",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "spack": {
+        "type": "object",
+        "default": {},
+        "additionalProperties": true,
+        "properties": {
+          "specs": {
+            "type": "array",
+            "default": [],
+            "minItems": 1,
+            "items": {
+              "type": "string"
+            }
+          },
+          "definitions": {
+            "type": "array",
+            "default": [],
+            "items": {
+              "type": "object",
+              "properties": {
+                "when": {
+                  "type": "string"
+                },
+                "ROOT_PACKAGE": {
+                  "type": "array",
+                  "minItems": 1,
+                  "maxItems": 1,
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "ROOT_SPEC": {
+                  "type": "array",
+                  "items": {
+                    "type":"object",
+                    "properties": {
+                      "matrix": {
+                        "type": "array",
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "exclude": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "if": {
+      "properties": {
+        "spack": {
+          "type": "object",
+          "properties": {
+            "specs": {
+              "type": "array",
+              "contains": {
+                "const": "$ROOT_SPEC"
+              }
+            }
+          }
+        }
+      }
+    },
+    "then": {
+      "properties": {
+        "spack": {
+          "type": "object",
+          "properties": {
+            "definitions": {
+              "allOf": [
+                {
+                  "type": "array",
+                  "contains": {
+                    "type": "object",
+                    "required": ["ROOT_SPEC"]
+                  }
+                },
+                {
+                  "type": "array",
+                  "contains": {
+                    "type": "object",
+                    "required": ["ROOT_PACKAGE"]
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  }

--- a/au.org.access-nri/tools/spack/environment/deployment/2-0-0.json
+++ b/au.org.access-nri/tools/spack/environment/deployment/2-0-0.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/tools/spack/environment/deployment/1-0-0.json",
+    "$id": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/tools/spack/environment/deployment/2-0-0.json",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Restricted spack environment file schema for ACCESS-NRI continuous deployment (general software deployment)",
     "description": "This schema was adapted from https://github.com/ACCESS-NRI/spack/blob/releases/v0.21/lib/spack/spack/schema/env.py to specify a restricted form of spack.yaml to design generic deployment infrastructure.",
@@ -11,6 +11,59 @@
         "default": {},
         "additionalProperties": true,
         "properties": {
+          "repos": {
+            "type": "object",
+            "default": {},
+            "additionalProperties": true,
+            "properties": {
+              "access_spack_packages": {
+                "type": "object",
+                "default": {},
+                "additionalProperties": false,
+                "properties": {
+                  "git": {
+                    "const": "https://github.com/ACCESS-NRI/access-spack-packages.git"
+                  },
+                  "tag": {
+                    "type": "string"
+                  },
+                  "branch": {
+                    "type": "string"
+                  },
+                  "commit": {
+                    "type": "string"
+                  },
+                  "destination": {
+                    "const": "$env/.package_repos/access-spack-packages"
+                  }
+                },
+                "required": [
+                  "git",
+                  "destination"
+                ],
+                "oneOf": [
+                  {
+                    "required": [
+                      "tag"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "branch"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "commit"
+                    ]
+                  }
+                ]
+              }
+            },
+            "required": [
+              "access_spack_packages"
+            ]
+          },
           "specs": {
             "type": "array",
             "default": [],
@@ -21,7 +74,104 @@
           },
           "definitions": {
             "type": "array",
-            "default": [],
+            "minItems": 5,
+            "allOf": [
+              {
+                "type": "array",
+                "contains": {
+                  "type": "object",
+                  "required": ["_name"],
+                  "properties": {
+                    "_name": {
+                      "type": "array",
+                      "minItems": 1,
+                      "maxItems": 1,
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "type": "array",
+                "contains": {
+                  "type": "object",
+                  "required": ["_version"],
+                  "properties": {
+                    "_name": {
+                      "type": "array",
+                      "minItems": 1,
+                      "maxItems": 1,
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "type": "array",
+                "contains": {
+                  "type": "object",
+                  "required": ["_spack-version"],
+                  "properties": {
+                    "_spack-version": {
+                      "type": "array",
+                      "minItems": 1,
+                      "maxItems": 1,
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "type": "array",
+                "contains": {
+                  "type": "object",
+                  "required": ["_provenance"],
+                  "properties": {
+                    "_provenance": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "type": "array",
+                "contains": {
+                  "type": "object",
+                  "required": ["_injection"],
+                  "properties": {
+                    "_injection": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "type": "array",
+                "contains": {
+                  "type": "object",
+                  "properties": {
+                    "_custom-scopes": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            ],
             "items": {
               "type": "object",
               "properties": {

--- a/au.org.access-nri/tools/spack/environment/deployment/CHANGELOG.md
+++ b/au.org.access-nri/tools/spack/environment/deployment/CHANGELOG.md
@@ -1,5 +1,11 @@
 # General Software `spack.yaml` Schema Changelog
 
+## 2-0-0
+
+* Require reserved definitions for `_spack-version`, `_provenance`, `_injection`
+* Require `spack.repos.access_spack_packages` section, with a constant `spack.repos.access_spack_packages.destination`
+* Optional reserved definition for `_custom-scopes`
+
 ## 1-0-0
 
 * Initial release


### PR DESCRIPTION
References ACCESS-NRI/build-cd#404
Closes #76

## Background

See the linked issue for the motivation.

We're removing the `config/{versions,packages}.json` files from MDRs and SDRs, and hence we no longer need to use those schemas.
The information from those files is being incorporated into reserved definitions in the `spack.yaml`, and the `spack.repos` section in the `spack.yaml`, as well.

## Reviewing the changes

Schemas are very annoying to review. But I've split it into copying the schema and adding in the changes, so it should be a little easier...

* MDR changes are in https://github.com/ACCESS-NRI/schema/pull/77/commits/59e92fa1dfaded10aa8e7fc99b770186be9c83fd
* SDR changes are in https://github.com/ACCESS-NRI/schema/pull/77/commits/75dc8d1d69a6ff274f05cb633ef91b5ce18a4172
* Deprecation notices for the `config/` files are in https://github.com/ACCESS-NRI/schema/pull/77/commits/7ad0584ec09c5471396079da5a43a26d2df643ec

## The PR

- **Deprecate config/{versions,packages}.json schema**
- **MDR spack.yaml schema: Add 3-0-0**
- **MDR spack.yaml schema: add required spack.repos.access_spack_packages section with constraints on keys within, add reserved definitions constraints, update changelog**
- **SDR spack.yaml schema: Add 2-0-0**
- **SDR spack.yaml schema: add required spack.repos.access_spack_packages section with constraints on keys within, added reserved defs constraints, update changelog**

## Testing

### MDR ACCESS-ESM1.6

<details>

#### Valid

```yaml
spack:
  definitions:
  # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
  - _name: [access-esm1p6]
  - _version: [2026.04.000]
  # _spack-version and _custom-scopes inform the branch of spack to use, and custom scopes if applicable, respectively
  - _spack-version: ["1.1"]
  - _custom-scopes: ["ukmo-restricted-scope"]
  # Release database provenance information - packages for inclusion into the database, and packages just for injection into the modules
  - _provenance: ["cice5", "um7", "mom5", "oasis3-mct", "cable", "gcom4", "access-fms", "access-generic-tracers", "access-mocsy"]
  - _injection: []
  # ...
  repos:
    access_spack_packages:
      git: https://github.com/ACCESS-NRI/access-spack-packages.git
      tag: 2026.02.002
      destination: $env/.package_repos/access-spack-packages
```

This is valid, given `ajv -s au.org.access-nri/model/spack/environment/deployment/3-0-0.json -d ../ACCESS-ESM1.6/spack.yaml`

#### Invalid (Incompatible `spack.repos` section)

The first manifest, but:

```yaml
spack:
  # ...
  repos:
    access_spack_packages:
      git: https://github.com/ACCESS-NRI/no-spack-packages.git
      tag: 2026.02.002
      destination: $env/.package_repos/somewhere-else/access-spack-packages
```

fails with `must be equal to constant`

#### Invalid (Missing required reserved definitions)

The first manifest, but:

```yaml
spack:
  definitions:
  # ...
  # - _spack-version: ["1.1"]
  - _custom-scopes: ["ukmo-restricted-scope"]
  # ...
```

fails with `must contain at least 1 valid item (_spack-version)`

</details>

### SDR model-tools (fre-nctools)

<details>

#### Valid

```yaml
spack:
  definitions:
  # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
  - _name: [fre-nctools]
  - _version: [2024.05-1]
  # _spack-version informs the branch of spack to use
  - _spack-version: ["1.1"]
  # Release database provenance information - packages for inclusion into the database, and packages just for injection into the modules
  - _provenance: []
  - _injection: []
  # ...
  repos:
    access_spack_packages:
      git: https://github.com/ACCESS-NRI/access-spack-packages.git
      tag: 2026.02.002
      destination: $env/.package_repos/access-spack-packages
```


This is valid, given `ajv -s au.org.access-nri/tools/spack/environment/deployment/2-0-0.json -d ../model-tools/fre-nctools/spack.yaml`.

#### Invalid (Incompatible `spack.repos` section)

The first manifest, but:

```yaml
spack:
  # ...
  repos:
    access_spack_packages:
      git: https://github.com/ACCESS-NRI/access-spack-packages.git
      tag: 2026.02.002
      # destination: $env/.package_repos/somewhere-else/access-spack-packages
```

fails with `must have required property 'destination'`

#### Invalid (Missing required reserved definitions)

The first manifest, but:

```yaml
spack:
  definitions:
  # ...
  # - _spack-version: ["1.1"]
  # ...
```

fails with `must contain at least 1 valid item (_spack-version)`

</details>
