### PR TITLE
For spack.repos.*.destination, use package-repos over .package_repos

### DIFF
--- a/au.org.access-nri/model/spack/environment/deployment/3-0-0.json
+++ b/au.org.access-nri/model/spack/environment/deployment/3-0-0.json
@@ -34,7 +34,7 @@
                     "type": "string"
                   },
                   "destination": {
-                    "const": "$env/.package_repos/access-spack-packages"
+                    "const": "$env/package-repos/access-spack-packages"
                   }
                 },
                 "required": [

--- a/au.org.access-nri/tools/spack/environment/deployment/2-0-0.json
+++ b/au.org.access-nri/tools/spack/environment/deployment/2-0-0.json
@@ -34,7 +34,7 @@
                     "type": "string"
                   },
                   "destination": {
-                    "const": "$env/.package_repos/access-spack-packages"
+                    "const": "$env/package-repos/access-spack-packages"
                   }
                 },
                 "required": [


### PR DESCRIPTION
See https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/209#discussion_r3746201446

## Background

We are going with `$env/package-repos` over `$env/.package_repos` due to:

* Hidden directories being bad user experience
* `package_repos` mirroring spacks own paths

This outweighs the strange behavior in which one clones `builtin` under `$env`, which creates 20+ environments that are within the builtin repository now. 

## The PR

* Update the existing MDR and SDR schemas...before they are widely used!
